### PR TITLE
Error: Using $this when not in object context

### DIFF
--- a/src/Cviebrock/EloquentSluggable/Sluggable.php
+++ b/src/Cviebrock/EloquentSluggable/Sluggable.php
@@ -149,12 +149,14 @@ class Sluggable {
 			{
 				return true;
 			}
+			
+			$self = $this;
 
 			// does the exact new slug exist, or did we create a new slug because of a reserved word?
 			if ( $base_slug != $slug || in_array($slug, $list) )
 			{
 				// filter the collection to only include the base slug, or the base slug + separator + number
-				$collection->filter( function($obj) use ($base_slug, $separator, $save_to)
+				$collection->filter( function($obj) use ($self, $base_slug, $separator, $save_to)
 				{
 					// keep the base slug
 					if ( $obj->{$save_to} === $base_slug )
@@ -162,7 +164,7 @@ class Sluggable {
 						return true;
 					}
 
-					return $this->isIncremented( $obj->{$save_to}, $base_slug, $separator);
+					return $self->isIncremented( $obj->{$save_to}, $base_slug, $separator);
 
 				});
 
@@ -199,7 +201,7 @@ class Sluggable {
 	 * @param  string  $separator The separator
 	 * @return boolean
 	 */
-	protected function isIncremented( $slug, $base_slug, $separator )
+	public function isIncremented( $slug, $base_slug, $separator )
 	{
 		if ( strpos($slug, $base_slug.$separator) === 0 )
 		{


### PR DESCRIPTION
First save "test", after save "test 2" and final save "test". Sluggable library dump "Using $this when not in object context" error. Already this library not work Category::save(Input::all()). This request fix errors.
