### PR TITLE
Fix slug update when $build_from value don't chage

### DIFF
--- a/src/Cviebrock/EloquentSluggable/Sluggable.php
+++ b/src/Cviebrock/EloquentSluggable/Sluggable.php
@@ -130,12 +130,14 @@ class Sluggable {
 			if ( $include_trashed )
 			{
 				$collection = $class::where($save_to, 'LIKE', $base_slug.'%')
+					->where($model->getKeyName(), '!=', $model->{$model->getKeyName()})
 					->withTrashed()
 					->get();
 			}
 			else
 			{
 				$collection = $class::where($save_to, 'LIKE', $base_slug.'%')
+					->where($model->getKeyName(), '!=', $model->{$model->getKeyName()})
 					->get();
 			}
 


### PR DESCRIPTION
Fix the slug to change from "foo" for "foo-1" when updating with the same build_from value.
