### PR TITLE
Add The Ability To Use The Cache To Prevent Race Conditions on Indexes

### DIFF
--- a/src/Cviebrock/EloquentSluggable/Sluggable.php
+++ b/src/Cviebrock/EloquentSluggable/Sluggable.php
@@ -1,6 +1,7 @@
 <?php namespace Cviebrock\EloquentSluggable;
 
 use Closure;
+use Cache;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 
@@ -187,10 +188,21 @@ class Sluggable {
 				// find the "highest" numbered version of the slug and increment it.
 				$idx = substr($collection->last()->{$save_to}, strlen($base_slug.$separator));
 				$idx = intval($idx);
+
+        $cachePrefix = "sluggable";
+        $cacheKey    = $cachePrefix . $slug;
+
+        //Get The Most Recent Idx out of the Cache
+        $idx = Cache::get($cacheKey, $idx);
+
+        //Increment The Index
 				$idx++;
 
-				$slug = $base_slug . $separator . $idx;
+        //Put The Index In The Cache, Locking It From Others From using
+        //One Minute Should Be Plenty Long To Prevent Race Conditions
+        Cache::put($cacheKey, $idx, 1);
 
+				$slug = $base_slug . $separator . $idx;
 			}
 
 		}


### PR DESCRIPTION
I've been using this on a site I have that generates models rapidly and found that Eloquent-Sluggable would use duplicate indexes for slugs if generated quickly. It's not so much a problem with the library but more a fact that looking up indexes in a database can be a bit slow. This version of the library will now look up the index in the database and also consult the cache so that an index can be locked.

It's a bit raw right now as I needed a quick fix for my project, but it might be helpful to someone. Disregard if not.
