### PR TITLE
Moving logic to get existing similar slugs, to it's own function, out of...

### DIFF
--- a/src/Cviebrock/EloquentSluggable/SluggableTrait.php
+++ b/src/Cviebrock/EloquentSluggable/SluggableTrait.php
@@ -161,7 +161,8 @@ trait SluggableTrait {
 	protected function getExistingSlugs($slug)
 	{
 		$instance = new static;
-		$query = $instance->where( $this->sluggable['save_to'], 'LIKE', $slug.'%' );
+		$save_to = $this->sluggable['save_to'];
+		$query = $instance->where( $save_to, 'LIKE', $slug.'%' );
 
 		// include trashed models if required
 		if ( $this->sluggable['include_trashed'] )


### PR DESCRIPTION
... makeSlugUnique() to make extending the trait simpler, by separating a unit functionality
