### PR TITLE
Prevent empty slugs.

### DIFF
--- a/src/Cviebrock/EloquentSluggable/SluggableTrait.php
+++ b/src/Cviebrock/EloquentSluggable/SluggableTrait.php
@@ -9,11 +9,16 @@ trait SluggableTrait {
 		$save_to = $this->sluggable['save_to'];
 		$on_update = $this->sluggable['on_update'];
 
+		// Never allow empty slugs!
+		if (empty($this->{$save_to})) {
+			return true;
+		}
+
 		if ($this->isDirty($save_to)) {
 			return false;
 		}
 
-		return ( !$this->exists || empty($this->{$save_to}) || $on_update );
+		return !$this->exists || $on_update;
 	}
 
 


### PR DESCRIPTION
You said [here](https://github.com/cviebrock/eloquent-sluggable/issues/21#issuecomment-37568515) that would be nice "check to make sure the slug isn't set to null or an empty value", so I've made this in `needsSlugging` method. This way we can say "keep slug field unfilled to generate it automatically" even in new registers, in which a empty string is considered dirt enough.

Hope it is useful.
