### PR TITLE
Run max_length option only if slug is a string

### DIFF
--- a/src/Cviebrock/EloquentSluggable/SluggableTrait.php
+++ b/src/Cviebrock/EloquentSluggable/SluggableTrait.php
@@ -67,7 +67,7 @@ trait SluggableTrait {
 			throw new \UnexpectedValueException("Sluggable method is not a callable, closure or null.");
 		}
 
-		if ($max_length)
+		if (is_string($slug) && $max_length)
 		{
 			$slug = substr($slug, 0, $max_length);
 		}


### PR DESCRIPTION
Just a little variable type validation before running substr() to adjust the slug to the max_length option. 
This allows the slug to be saved as NULL in the database, for example, when returning a NULL value from a custom method's closure.
