### PR TITLE
Adding Failing test for incremental ids

### DIFF
--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -527,5 +527,34 @@ class SluggableTest extends TestCase {
 		$post1->save();
 		$this->assertEquals('a-post-title', $post1->slug);
 	}
+	
+	/**
+	 * Test that it does not update a slug if there's no need too
+	 *
+	 * @test
+	 */
+	public function testItDoesNotIncrementIdOnSlugIfNotRequired()
+	{
+		$post1 = $this->makePost('A post title');
+		$post1->setSlugConfig(array(
+			'on_update' => true,
+		));
+		$post1->save();
+		$this->assertEquals('a-post-title', $post1->slug);
+
+		$post2 = $this->makePost('A post title');
+		$post2->setSlugConfig(array(
+			'on_update' => true,
+		));
+		
+		$post2->save();
+		$this->assertEquals('a-post-title-1', $post2->slug);
+		
+		$post2->save();
+		$this->assertEquals('a-post-title-1', $post2->slug);
+
+		$post1->save();
+		$this->assertEquals('a-post-title', $post1->slug);
+	}
 
 }


### PR DESCRIPTION
Issue - when saving post 2 more than once it should not be updating that slug to a-post-title-2 but it is (where as the behaviour for post one is working as expected)

@cviebrock It's for this issue here https://github.com/cviebrock/eloquent-sluggable/issues/59#issuecomment-59854928

I think this looks about right to replicate the issue