### PR TITLE
Updated findBySlug to return the first object rather than a redundant co...

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ There is also a handy helper in the trait for finding a model based on it's slug
 $post = Post::findBySlug('my-slug');
 ```
 
-This is basically a wrapper for `Post::where('slug-field','=','my-slug')->get()`.
+This is basically a wrapper for `Post::where('slug-field','=','my-slug')->get()->first()`.
 
 
 

--- a/src/Cviebrock/EloquentSluggable/SluggableTrait.php
+++ b/src/Cviebrock/EloquentSluggable/SluggableTrait.php
@@ -240,7 +240,7 @@ trait SluggableTrait {
 		$config = \App::make('config')->get('eloquent-sluggable::config');
 		$config = array_merge( $config, $instance->sluggable );
 
-		return $instance->where( $config['save_to'], $slug )->get();
+		return $instance->where( $config['save_to'], $slug )->get()->first();
 	}
 
 }

--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -430,7 +430,7 @@ class SluggableTest extends TestCase {
 		$post3 = $this->makePost('My third post');
 		$post3->save();
 
-		$post = Post::findBySlug('my-second-post')->first();
+		$post = Post::findBySlug('my-second-post');
 
 		$this->assertEquals($post2->id, $post->id);
 	}


### PR DESCRIPTION
Just a small change that just makes a little bit of sense as slugs must be unique.

Develop is out of sync, hope you don't mind I'm making the pull request to master.
