### PR TITLE
Ensure $this->sluggable is an array

### DIFF
--- a/src/Cviebrock/EloquentSluggable/SluggableTrait.php
+++ b/src/Cviebrock/EloquentSluggable/SluggableTrait.php
@@ -208,7 +208,7 @@ trait SluggableTrait {
 	public function sluggify($force=false)
 	{
 		$config = \App::make('config')->get('eloquent-sluggable::config');
-		$this->sluggable = array_merge( $config, $this->sluggable );
+		$this->sluggable = array_merge( $config, (array) $this->sluggable );
 
 		if ($force || $this->needsSlugging())
 		{


### PR DESCRIPTION
If the property is not defined on a model (because all models share the same config and there is no need for it) this will fail as `array_merge` will complain $this->sluggable is not an array
