### PR TITLE
Fixed tests

### DIFF
--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Foundation\Application;
 use Orchestra\Testbench\TestCase;
 
 
@@ -53,9 +54,10 @@ class SluggableTest extends TestCase {
   /**
    * Get Sluggable package providers.
    *
+   * @param Application $app
    * @return array
    */
-	protected function getPackageProviders()
+	protected function getPackageProviders($app)
 	{
 		return array('Cviebrock\EloquentSluggable\SluggableServiceProvider');
 	}


### PR DESCRIPTION
[this](https://github.com/hannesvdvreken/eloquent-sluggable/blob/develop/tests/SluggableTest.php#L58) was no longer compatible with [that](https://github.com/orchestral/testbench/blame/master/src/Testbench/Traits/ApplicationTrait.php#L140) since 2 days.

I recommend using a tagged version of testbench.