### PR TITLE
Fix non-existent "package" method call

### DIFF
--- a/src/Cviebrock/EloquentSluggable/SluggableServiceProvider.php
+++ b/src/Cviebrock/EloquentSluggable/SluggableServiceProvider.php
@@ -17,10 +17,7 @@ class SluggableServiceProvider extends ServiceProvider {
 	 *
 	 * @return void
 	 */
-	public function boot()
-	{
-		$this->package('cviebrock/eloquent-sluggable');
-	}
+	public function boot() {}
 
 	/**
 	 * Register the service provider.


### PR DESCRIPTION
Remove call to "package" method which doesn't exist anymore as per
https://github.com/illuminate/support/blob/master/ServiceProvider.php