### PR TITLE
Add whereSlug method to return a Builder instance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,8 +3,8 @@
 - [x] Write tests
 - [ ] Better docblock and inline-commenting
 - [ ] Make code style consistent
-- [ ] Drop `develop` branch and just have `master` and tagged releases
-- [ ] Add check that model uses softDelete trait when using `with_trashed` (see issue #47)
+- [x] Drop `develop` branch and just have `master` and tagged releases
+- [x] Add check that model uses softDelete trait when using `with_trashed` (see issue #47)
 
 
 ## Planned changes (possibly BC-breaking) for next major version
@@ -12,3 +12,5 @@
 - [ ] switch default slugging method from `Str::slug` to an external package/class that can handle transliteration of other languages (e.g. https://github.com/cocur/slugify)
 - [ ] convert `findBySlug` into a scope (as suggested by @unitedworks in #40)
 - [ ] more configurable `unique` options (see issue #53)
+- [ ] refactor, or remove, caching code (it wasn't really thought out well enough, IMO)
+- [ ] add events, e.g. `eloquent.slug.created`, `eloquent.slug.changed`, etc. (as suggested in #96 and #101)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "cviebrock/eloquent-sluggable",
-	"description": "Easy creation of slugs for your Eloquent models in Laravel 5.",
+	"description": "Easy creation of slugs for your Eloquent models in Laravel",
 	"keywords": ["laravel","eloquent","slug"],
 	"homepage": "https://github.com/cviebrock/eloquent-sluggable",
 	"license": "MIT",

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -225,16 +225,19 @@ trait SluggableTrait {
 		return $this->sluggify(true);
 	}
 
-
-	public static function getBySlug($slug)
+	public static function whereSlug($slug)
 	{
-
 		$instance = new static;
 
 		$config = \App::make('config')->get('sluggable');
 		$config = array_merge( $config, $instance->sluggable );
 
-		return $instance->where( $config['save_to'], $slug )->get();
+		return $instance->where( $config['save_to'], $slug );
+	}
+
+	public static function getBySlug($slug)
+	{
+		return static::whereSlug($slug)->get();
 	}
 
 	public static function findBySlug($slug)


### PR DESCRIPTION
When I was using eloquent-sluggable I noted that  there is no out of the box method to use the slug as a where clause. 

Now when using the whereSlug method it will return an instance of Builder.