### PR TITLE
Adding scope to unique slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ return array(
 	'method'          => null,
 	'separator'       => '-',
 	'unique'          => true,
+	'scoped'          => null,
 	'include_trashed' => false,
 	'on_update'       => false,
 	'reserved'        => null,
@@ -258,6 +259,10 @@ This defines the separator used when building a slug, and is passed to the `meth
 This is a boolean defining whether slugs should be unique among all models of the given type. For example, if you have two blog posts and both are called "My Blog Post", then they will both sluggify to "my-blog-post" (when using Sluggable's default settings). This could be a problem, e.g. if you use the slug in URLs.
 
 By turning `unique` on, then the second Post model will sluggify to "my-blog-post-1". If there is a third post with the same title, it will sluggify to "my-blog-post-2" and so on. Each subsequent model will get an incremental value appended to the end of the slug, ensuring uniqueness.
+
+### scoped
+
+You can use this variable if you use unique words as limited to any particular model column.
 
 ### include_trashed
 

--- a/config/sluggable.php
+++ b/config/sluggable.php
@@ -72,6 +72,22 @@ return array(
 	'unique' => true,
 
 	/**
+	 * You can use this variable if you use unique words as limited 
+	 * to any particular model column.
+	 * 
+	 * For example, assume that your model has a column named scope_id
+	 * and you want the slugs to be unique for each scope separately 
+	 * then 'scoped' => "scope_id". eg:
+	 *
+	 *     scope1	my-slug
+	 *     scope1	my-slug-1
+	 *     scope2	my-slug
+	 *     scope1	my-slug-2
+	 *     scope2	my-slug-1
+	 */
+	'scoped' => null,
+	
+	/**
 	 * Should we include the trashed items when generating a unique slug?
 	 * This only applies if the softDelete property is set for the Eloquent model.
 	 * If set to "false", then a new slug could duplicate one that exists on a trashed model.

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -162,11 +162,19 @@ trait SluggableTrait {
 	{
 		$save_to         = $this->sluggable['save_to'];
 		$include_trashed = $this->sluggable['include_trashed'];
+        	$scoped          = $this->sluggable['scoped'];
 
 		$instance = new static;
 
 		$query = $instance->where( $save_to, 'LIKE', $slug.'%' );
-
+		
+	        // restirct with scope
+	        if ( $scoped )
+	        {
+	            $scoped_value = $this->{$scoped};
+	            $query = $query->where( $scoped, '=', $scoped_value );
+	        }
+        
 		// include trashed models if required
 		if ( $include_trashed && $this->usesSoftDeleting() )
 		{


### PR DESCRIPTION
A variable added to config named scoped. You can use this variable if you use unique words as limited  to any particular model column.