### PR TITLE
Improve sluggable:table command handling in L5

### DIFF
--- a/src/SluggableMigrationCreator.php
+++ b/src/SluggableMigrationCreator.php
@@ -1,0 +1,60 @@
+<?php namespace Cviebrock\EloquentSluggable;
+
+use Illuminate\Database\Migrations\MigrationCreator;
+
+class SluggableMigrationCreator extends MigrationCreator {
+
+	/**
+	 * Slug column name
+	 *
+	 * @var string
+	 */
+	protected $column = 'slug';
+
+	/**
+	 * Get the path to the stubs folder
+	 *
+	 * @return string
+	 */
+	public function getStubPath()
+	{
+		return __DIR__ . '/../stubs';
+	}
+
+	/**
+	 * Get the migration stub file.
+	 *
+	 * @param  string  $table
+	 * @param  bool    $create
+	 * @return string
+	 */
+	protected function getStub($table, $create)
+	{
+		return $this->files->get($this->getStubPath().'/migration.stub');
+	}
+
+	/**
+	 * Populate the place-holders in the migration stub.
+	 *
+	 * @param  string  $name
+	 * @param  string  $stub
+	 * @param  string  $table
+	 * @param  string  $column
+	 * @return string
+	 */
+	protected function populateStub($name, $stub, $table)
+	{
+		$stub = parent::populateStub($name, $stub, $table);
+
+		return str_replace('{{column}}', $this->column, $stub);
+	}
+
+	/**
+	 * @param string $column
+	 */
+	public function setColumn($column)
+	{
+		$this->column = $column;
+	}
+
+}

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AddSluggableColumns extends Migration {
+class {{class}} extends Migration {
 
 	/**
 	 * Run the migrations.
@@ -12,9 +12,9 @@ class AddSluggableColumns extends Migration {
 	 */
 	public function up()
 	{
-		Schema::table('sluggable_table', function(Blueprint $table)
+		Schema::table('{{table}}', function(Blueprint $table)
 		{
-			$table->string('sluggable_column')->nullable();
+			$table->string('{{column}}')->nullable();
 		});
 	}
 
@@ -25,9 +25,9 @@ class AddSluggableColumns extends Migration {
 	 */
 	public function down()
 	{
-		Schema::table('sluggable_table', function(Blueprint $table)
+		Schema::table('{{table}}', function(Blueprint $table)
 		{
-			$table->dropColumn('sluggable_column');
+			$table->dropColumn('{{column}}');
 		});
 	}
 


### PR DESCRIPTION
This commit introduces several fixes to improve the `sluggable:table` command handling in L5:
- Fix wrong path to the `stubs` folder
- Customize the generated migration name to include the table and column being added
- Avoid double-writing of the generated migration file

This is accomplished through the following changes:
- New `SluggableMigrationCreator` class that reuses L5's codebase (MigrationCreator) to generate the migration file
- Simplified `SluggableTableCommand` that delegates stub handling logic to `SluggableMigrationCreator`
- Edited `SluggableServiceProvider` to wire up the above classes