### PR TITLE
Allow a model to have a 'uniqueMethod' settings

### DIFF
--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -217,6 +217,27 @@ class SluggableTest extends TestCase {
 		$this->assertEquals('eltit-tsop-a', $post->slug);
 	}
 
+    /**
+     * Test building a slug using a custom suffix.
+     *
+     * @test
+     */
+    public function testCustomSuffix()
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $post = new PostSuffix;
+            $post->title = 'A Post Title';
+            $post->subtitle = 'A Subtitle';
+            $post->save();
+
+            if ($i === 0) {
+                $this->assertEquals('a-post-title', $post->slug);
+            } else {
+                $this->assertEquals('a-post-title-' . chr($i + 96), $post->slug);
+            }
+        }
+    }
+
 	/**
 	 * Test building a slug using the __toString method
 	 *

--- a/tests/models/PostSuffix.php
+++ b/tests/models/PostSuffix.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class PostSuffix extends Post {
+    protected $sluggable = array(
+        'build_from'    => 'title',
+        'save_to'       => 'slug',
+        'uniqueMethod'  => 'generateUnique',
+    );
+
+    /**
+     * @param $slug
+     * @param $list
+     *
+     * @return string
+     */
+    protected function generateUnique($slug, $list)
+    {
+        $size = count($list);
+        return chr($size + 96);
+    }
+}


### PR DESCRIPTION
Pull request for #119 

This adds an extra option within a model to allow unique suffixes to be generated by the model rather than just incrementing a counter.

The test case uses this to generate posts which are suffixed with a lower case letter, but a more realistic example would be to return a random number (not in use) to hide the number of previous generated entities.
