### PR TITLE
Wrapped package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The **Eloquent-Sluggable** package for Laravel 5 will handle all of this for you
 First, you'll need to require the package with Composer:
 
 ```bash
-$ composer require cviebrock/eloquent-sluggable >=3.0.0-alpha
+$ composer require cviebrock/eloquent-sluggable ">=3.0.0-alpha"
 ```
 
 > **NOTE**: Eloquent-Sluggable now uses traits, so you will need to be running PHP 5.4 or higher. If you are still using 5.3, then use the "1.*" version and follow the instructions in that version's README.md file.


### PR DESCRIPTION
`composer require cviebrock/eloquent-sluggable >=3.0.0-alpha` creates empty `=3.0.0-alpha` file in the root of my project.

`composer require cviebrock/eloquent-sluggable ">=3.0.0-alpha"` works correctly.

OS: Ubuntu 14.10
Composer: 1.0-dev (f10c71475167a4661225b14560ca0a400d730829)
PHP: PHP 5.5.12