### PR TITLE
Allow a model to have a 'generateSuffix' method

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -145,22 +145,32 @@ trait SluggableTrait {
 			return $slug;
 		}
 
+		$suffix = $this->generateSuffix($slug, $list);
 
-		// map our list to keep only the increments
-		$len = strlen($slug.$separator);
-		array_walk($list, function(&$value, $key) use ($len)
-		{
+		return $slug . $separator . $suffix;
+
+	}
+
+	/**
+	 * @param string $slug
+	 * @param array  $list
+	 *
+	 * @return string
+	 */
+	protected function generateSuffix($slug, $list)
+	{
+		$config = $this->getSluggableConfig();
+		$separator  = $config['separator'];
+		$len = strlen($slug . $separator);
+
+		array_walk($list, function (&$value, $key) use ($len) {
 			$value = intval(substr($value, $len));
 		});
 
 		// find the highest increment
 		rsort($list);
-		$increment = reset($list) + 1;
-
-		return $slug . $separator . $increment;
-
+		return reset($list) + 1;
 	}
-
 
 	protected function getExistingSlugs($slug)
 	{

--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -217,6 +217,27 @@ class SluggableTest extends TestCase {
 		$this->assertEquals('eltit-tsop-a', $post->slug);
 	}
 
+    /**
+     * Test building a slug using a custom suffix.
+     *
+     * @test
+     */
+    public function testCustomSuffix()
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $post = new PostSuffix;
+            $post->title = 'A Post Title';
+            $post->subtitle = 'A Subtitle';
+            $post->save();
+
+            if ($i === 0) {
+                $this->assertEquals('a-post-title', $post->slug);
+            } else {
+                $this->assertEquals('a-post-title-' . chr($i + 96), $post->slug);
+            }
+        }
+    }
+
 	/**
 	 * Test building a slug using the __toString method
 	 *

--- a/tests/models/PostSuffix.php
+++ b/tests/models/PostSuffix.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class PostSuffix extends Post {
+    protected $sluggable = array(
+        'build_from'    => 'title',
+        'save_to'       => 'slug',
+    );
+
+    /**
+     * @param string $slug
+     * @param array  $list
+     *
+     * @return string
+     */
+    protected function generateSuffix($slug, $list)
+    {
+        $size = count($list);
+        return chr($size + 96);
+    }
+}


### PR DESCRIPTION
This is an alternative version to #120 for issue #119 

Instead of having it as an setting, a model can just override the `generateSuffix` method when required.