### PR TITLE
"include_trashed" doesn't work for models that inherit the SoftDeletes trait

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -186,7 +186,14 @@ trait SluggableTrait {
 
 
 	protected function usesSoftDeleting() {
-		return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses($this));
+		$softDeleteStrait = 'Illuminate\Database\Eloquent\SoftDeletes';
+		$classes = array_merge([get_class($this)], class_parents($this));
+		foreach( $classes as $class ) {
+			if ( in_array($softDeleteStrait, class_uses($class)) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -186,14 +186,7 @@ trait SluggableTrait {
 
 
 	protected function usesSoftDeleting() {
-		$softDeletesTrait = 'Illuminate\Database\Eloquent\SoftDeletes';
-		$classes = array_merge([get_class($this)], class_parents($this));
-		foreach( $classes as $class ) {
-			if ( in_array($softDeletesTrait, class_uses($class)) ) {
-				return true;
-			}
-		}
-		return false;
+		return method_exists($this,'BootSoftDeletes');
 	}
 
 

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -186,10 +186,10 @@ trait SluggableTrait {
 
 
 	protected function usesSoftDeleting() {
-		$softDeleteStrait = 'Illuminate\Database\Eloquent\SoftDeletes';
+		$softDeletesTrait = 'Illuminate\Database\Eloquent\SoftDeletes';
 		$classes = array_merge([get_class($this)], class_parents($this));
 		foreach( $classes as $class ) {
-			if ( in_array($softDeleteStrait, class_uses($class)) ) {
+			if ( in_array($softDeletesTrait, class_uses($class)) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
The ``usesSoftDeleting()`` function now checks parent classes as well when determining if the ``softdeletes`` trait is being used