### PR TITLE
Update for laravel 5.1

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -179,7 +179,7 @@ trait SluggableTrait {
 		}
 
 		// get a list of all matching slugs
-		$list = $query->lists($save_to, $this->getKeyName());
+		$list = $query->lists($save_to, $this->getKeyName())->all();
 
 		return $list;
 	}

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -179,7 +179,12 @@ trait SluggableTrait {
 		}
 
 		// get a list of all matching slugs
-		$list = $query->lists($save_to, $this->getKeyName())->all();
+		if(method_exists($query, 'all')){
+	            $list = $query->lists($save_to, $this->getKeyName())->all();
+	        }else{
+	            $list = $query->lists($save_to, $this->getKeyName());
+	        }
+
 
 		return $list;
 	}


### PR DESCRIPTION
The list method has changed for laravel 5.1, this change causes a fail every time a slug is created or retrieved

Laravel upgrade guide says : 
"The lists method now returns a Collection instance. If you would like to convert the Collection into a plain array, use the all method"

i made a check for L5 and 5.1 with "method_exists" i'm not sure if is clean, but it works.