### PR TITLE
Don't increment unique suffix if slug is unchanged

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -162,6 +162,14 @@ trait SluggableTrait {
 		$separator = $config['separator'];
 		$len = strlen($slug . $separator);
 
+		// If the slug already exists, but belongs to
+		// our model, return the current suffix.
+		if ($this->id === array_search($this->slug, $list))
+		{
+			$suffix = explode($separator, $this->slug);
+			return end($suffix);
+		}
+
 		array_walk($list, function (&$value, $key) use ($len) {
 			$value = intval(substr($value, $len));
 		});

--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -576,7 +576,6 @@ class SluggableTest extends TestCase {
 	 *
 	 * @test
 	 */
-
 	public function testNonStaticCallOfFindBySlug() {
 		$post1 = $this->makePost('My first post');
 		$post1->save();
@@ -585,5 +584,27 @@ class SluggableTest extends TestCase {
 		$resultId = $post->findBySlug('my-first-post')->id;
 
 		$this->assertEquals($post1->id, $resultId);
+	}
+
+	/**
+	 * Test that the unique suffix does not increment when the title
+	 * is unchanged in models where 'on_update' is set to true.
+	 * 
+	 * @test
+	 */
+	public function testUniqueSuffixDoesNotIncrement()
+	{
+		$post1 = new Post(['title' => 'My Test Post']);
+		$post1->save(); // my-test-post
+
+		$post2 = new Post(['title' => 'My Test Post']);
+		$post2->save(); // my-test-post-1
+
+		$post2->setSlugConfig(['on_update' => true]);
+
+		$post2->dummy = 'Some update happens, and the unique value increments...';
+		$post2->save(); // before fix, my-test-post-2
+
+		$this->assertEquals($post2->slug, 'my-test-post-1'); // previously failed
 	}
 }


### PR DESCRIPTION
Fix for issue #108. In models with on_update set to true, do not increment the unique suffix
if the model have been saved but the title is unchanged.