### PR TITLE
When creating new records (in a large database), a short slug previou…

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -185,7 +185,11 @@ trait SluggableTrait {
 
 		$instance = new static;
 
-		$query = $instance->where($save_to, 'LIKE', $slug . '%');
+		//check for direct match or something that has a separator followed by a suffix
+		$query = $instance->where(function ($query) use ($save_to, $config, $slug) {
+			$query->where($save_to, $slug);
+			$query->orWhere($save_to, 'LIKE', $slug . $config['separator'] . '%');
+		});
 
 		// include trashed models if required
 		if ($include_trashed && $this->usesSoftDeleting()) {


### PR DESCRIPTION
When creating new records (in a large database), a short slug previously matched too many records and caused a memory overflow.

This fix narrows down the results a little more, getting direct matches, or those which have had something appended (or the easiest closest approximation).