### PR TITLE
Set null slug when source is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ return [
 	'include_trashed' => false,
 	'on_update'       => false,
 	'reserved'        => null,
+	'null_when_empty' => false,
 ];
 ```
 
@@ -266,6 +267,10 @@ A boolean. If it is `false` (the default value), then slugs will not be updated 
 ### reserved
 
 An array of values that will never be allowed as slugs, e.g. to prevent collisions with existing routes or controller methods, etc.. This can be an array, or a closure that returns an array. Defaults to `null`: no reserved slug names.
+
+### null_when_empty
+
+If you want a *null* slug when the source is empty, set this parameter to *true*
 
 
 <a name="route-model"></a>

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ An array of values that will never be allowed as slugs, e.g. to prevent collisio
 
 ### null_when_empty
 
-If you want a *null* slug when the source is empty, set this parameter to *true*
+If you want a `null` slug when the source is empty, set this parameter to `true`
 
 
 <a name="route-model"></a>

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ return [
 	'include_trashed' => false,
 	'on_update'       => false,
 	'reserved'        => null,
-	'null_when_empty' => false,
 ];
 ```
 
@@ -267,11 +266,6 @@ A boolean. If it is `false` (the default value), then slugs will not be updated 
 ### reserved
 
 An array of values that will never be allowed as slugs, e.g. to prevent collisions with existing routes or controller methods, etc.. This can be an array, or a closure that returns an array. Defaults to `null`: no reserved slug names.
-
-### null_when_empty
-
-If you want a `null` slug when the source is empty, set this parameter to `true`
-
 
 <a name="route-model"></a>
 ##Route-model Binding

--- a/config/sluggable.php
+++ b/config/sluggable.php
@@ -109,10 +109,4 @@ return [
 	 * and continue from there.
 	 */
 	'reserved' => null,
-
-	/**
-	 * When the source field is empty, set slug at null
-	 * This avoids having slug like '-1', '-2' when unique is enabled
-	 */
-	'null_when_empty' => false,
 ];

--- a/config/sluggable.php
+++ b/config/sluggable.php
@@ -110,4 +110,9 @@ return [
 	 */
 	'reserved' => null,
 
+	/**
+	 * When the source field is empty, set slug at null
+	 * This avoids having slug like '-1', '-2' when unique is enabled
+	 */
+	'null_when_empty' => false,
 ];

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -67,6 +67,7 @@ trait SluggableTrait {
 		$separator = $config['separator'];
 		$method = $config['method'];
 		$max_length = $config['max_length'];
+		$null_when_empty = $config['null_when_empty'];
 
 		if ($method === null) {
 			$slug = (new Slugify)->slugify($source, $separator);
@@ -78,6 +79,10 @@ trait SluggableTrait {
 
 		if (is_string($slug) && $max_length) {
 			$slug = substr($slug, 0, $max_length);
+		}
+
+		if($null_when_empty && empty($source)){
+			$slug = null;
 		}
 
 		return $slug;

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -69,7 +69,9 @@ trait SluggableTrait {
 		$max_length = $config['max_length'];
 		$null_when_empty = $config['null_when_empty'];
 
-		if ($method === null) {
+		if($null_when_empty && empty($source)){
+			$slug = null;
+		}elseif ($method === null) {
 			$slug = (new Slugify)->slugify($source, $separator);
 		} elseif (is_callable($method)) {
 			$slug = call_user_func($method, $source, $separator);
@@ -80,11 +82,7 @@ trait SluggableTrait {
 		if (is_string($slug) && $max_length) {
 			$slug = substr($slug, 0, $max_length);
 		}
-
-		if($null_when_empty && empty($source)){
-			$slug = null;
-		}
-
+		
 		return $slug;
 	}
 

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -67,9 +67,8 @@ trait SluggableTrait {
 		$separator = $config['separator'];
 		$method = $config['method'];
 		$max_length = $config['max_length'];
-		$null_when_empty = $config['null_when_empty'];
 
-		if($null_when_empty && empty($source)){
+		if(empty($source)){
 			$slug = null;
 		}elseif ($method === null) {
 			$slug = (new Slugify)->slugify($source, $separator);
@@ -82,7 +81,7 @@ trait SluggableTrait {
 		if (is_string($slug) && $max_length) {
 			$slug = substr($slug, 0, $max_length);
 		}
-		
+
 		return $slug;
 	}
 


### PR DESCRIPTION
In my app, i have a slug generation dynamically and my source field can be blank.
Moreover, I set the unique option to `true`, so, after every insert with a empty field, I had slugs like 

- '-1'
- '-2'
- '-3'
....

I have not done phpunit tests because I prefer to let a professional do it !