### PR TITLE
Update stub placeholders for Laravel 5.1

### DIFF
--- a/src/SluggableMigrationCreator.php
+++ b/src/SluggableMigrationCreator.php
@@ -43,7 +43,7 @@ class SluggableMigrationCreator extends MigrationCreator {
 	protected function populateStub($name, $stub, $table) {
 		$stub = parent::populateStub($name, $stub, $table);
 
-		return str_replace('{{column}}', $this->column, $stub);
+		return str_replace('DummyColumn', $this->column, $stub);
 	}
 
 	/**

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -14,7 +14,7 @@ class DummyClass extends Migration {
 	{
 		Schema::table('DummyTable', function(Blueprint $table)
 		{
-			$table->string('{{column}}')->nullable();
+			$table->string('DummyColumn')->nullable();
 		});
 	}
 
@@ -27,7 +27,7 @@ class DummyClass extends Migration {
 	{
 		Schema::table('DummyTable', function(Blueprint $table)
 		{
-			$table->dropColumn('{{column}}');
+			$table->dropColumn('DummyColumn');
 		});
 	}
 

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class {{class}} extends Migration {
+class DummyClass extends Migration {
 
 	/**
 	 * Run the migrations.
@@ -12,7 +12,7 @@ class {{class}} extends Migration {
 	 */
 	public function up()
 	{
-		Schema::table('{{table}}', function(Blueprint $table)
+		Schema::table('DummyTable', function(Blueprint $table)
 		{
 			$table->string('{{column}}')->nullable();
 		});
@@ -25,7 +25,7 @@ class {{class}} extends Migration {
 	 */
 	public function down()
 	{
-		Schema::table('{{table}}', function(Blueprint $table)
+		Schema::table('DummyTable', function(Blueprint $table)
 		{
 			$table->dropColumn('{{column}}');
 		});


### PR DESCRIPTION
The latest version of Laravel 5.1 changed the placeholders to be more PSR2 friendly.

{{class}} is now DummyClass
{{table}} is now DummyTable.

This fixes the bug whereby the sluggable:table command would not be able to do all str_replace actions.