### PR TITLE
Update stub for Laravel 5.1 PSR2 changes

### DIFF
--- a/src/SluggableMigrationCreator.php
+++ b/src/SluggableMigrationCreator.php
@@ -52,7 +52,7 @@ class SluggableMigrationCreator extends MigrationCreator
     {
         $stub = parent::populateStub($name, $stub, $table);
 
-        return str_replace('{{column}}', $this->column, $stub);
+        return str_replace('DummyColumn', $this->column, $stub);
     }
 
     /**

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
 
-class {{class}} extends Migration
+class DummyClass extends Migration
 {
 
     /**
@@ -14,8 +14,8 @@ class {{class}} extends Migration
      */
     public function up()
     {
-        Schema::table('{{table}}', function (Blueprint $table) {
-            $table->string('{{column}}')->nullable();
+        Schema::table('DummyTable', function (Blueprint $table) {
+            $table->string('DummyColumn')->nullable();
         });
     }
 
@@ -26,8 +26,8 @@ class {{class}} extends Migration
      */
     public function down()
     {
-        Schema::table('{{table}}', function (Blueprint $table) {
-            $table->dropColumn('{{column}}');
+        Schema::table('DummyTable', function (Blueprint $table) {
+            $table->dropColumn('DummyColumn');
         });
     }
 


### PR DESCRIPTION
The placeholder used to string replace the Class, Table and Column name has changed in the latest version of Laravel 5.1.