### PR TITLE
Upd. SluggableTrait.php - handle key alternatives

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -61,6 +61,9 @@ trait SluggableTrait
      */
     protected function generateSource($key)
     {
+        $key_alternatives = explode('|',$key);
+        $key = $key_alternatives[0];
+        
         if (isset($this->{$key})) {
             return $this->{$key};
         }
@@ -68,7 +71,10 @@ trait SluggableTrait
         $object = $this;
         foreach (explode('.', $key) as $segment) {
             if (!is_object($object) || !$tmp = $object->{$segment}) {
-                return null;
+                if(!empty($key_alternatives[1]))
+                    return $this->generateSource($key_alternatives[1]);
+                else
+                    return null;
             }
 
             $object = $object->{$segment};


### PR DESCRIPTION
Permit to use this syntax to use alternative value if a field value is `null` in `build_from` param :
```
'build_from' => ['table.field|alternative_table.alternative_field'],
```