### PR TITLE
[Feature] Add a static slug generator

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -333,6 +333,21 @@ trait SluggableTrait
     }
 
     /**
+     * Generate a unique slug for a given string.
+     * 
+     * @param  string $fromString
+     * @return string
+     */
+    public static function createSlug($fromString)
+    {
+        $model = new self();
+        $slug = $model->generateSlug($fromString);
+        $slug = $model->validateSlug($slug);
+        
+        return $model->makeSlugUnique($slug);
+    }
+
+    /**
      * Query scope for finding a model by its slug.
      *
      * @param $scope

--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -783,4 +783,26 @@ class SluggableTest extends TestCase
         $this->assertEquals($post->subtitle, 'I have been slugged!');
     }
 
+    /**
+     * Test that we can generate a slug statically.
+     * 
+     * @test
+     */
+    public function testStaticSlugGenerator()
+    {
+        $this->assertEquals('my-test-post', Post::createSlug('My Test Post'));
+    }
+
+    /**
+     * Test that we generate unique slugs in a static context.
+     * 
+     * @test
+     */
+    public function testStaticSlugGeneratorWhenEntriesExist()
+    {
+        $post = Post::create(['title' => 'My Test Post']);
+
+        $this->assertEquals('my-test-post', $post->slug);
+        $this->assertEquals('my-test-post-1', Post::createSlug('My Test Post'));
+    }
 }

--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -668,8 +668,7 @@ class SluggableTest extends TestCase
         $post2->dummy = 'Some update happens, and the unique value increments...';
         $post2->save(); // before fix, my-test-post-2
 
-        $this->assertEquals($post2->slug,
-          'my-test-post-1'); // previously failed
+        $this->assertEquals('my-test-post-1', $post2->slug); // previously failed
     }
 
     /**
@@ -685,7 +684,7 @@ class SluggableTest extends TestCase
         ]);
         $post->author()->associate($author);
         $post->save();
-        $this->assertEquals($post->slug, 'arthur-conan-doyle-first');
+        $this->assertEquals('arthur-conan-doyle-first', $post->slug);
     }
 
     /**
@@ -699,7 +698,7 @@ class SluggableTest extends TestCase
           'title' => 'First'
         ]);
         $post->save();
-        $this->assertEquals($post->slug, 'first');
+        $this->assertEquals('first', $post->slug);
     }
 
     /**
@@ -715,7 +714,7 @@ class SluggableTest extends TestCase
         ]);
 
         $post->save();
-        $this->assertEquals($post->slug, null);
+        $this->assertEquals(null, $post->slug);
     }
 
     /**
@@ -729,7 +728,7 @@ class SluggableTest extends TestCase
           'title' => 'The quick brown fox jumps over the lazy dog'
         ]);
         $post->save();
-        $this->assertEquals($post->slug, 'tha-qaack-brawn-fax-jamps-avar-tha-lazy-dag');
+        $this->assertEquals('tha-qaack-brawn-fax-jamps-avar-tha-lazy-dag', $post->slug);
     }
 
     /**
@@ -746,7 +745,7 @@ class SluggableTest extends TestCase
 
         $post = new Post(['title' => 'My Test Post']);
         $post->save();
-        $this->assertEquals($post->slug, 'modified-by-event');
+        $this->assertEquals('modified-by-event', $post->slug);
     }
 
     /**
@@ -763,7 +762,7 @@ class SluggableTest extends TestCase
 
         $post = new Post(['title' => 'My Test Post']);
         $post->save();
-        $this->assertEquals($post->slug, null);
+        $this->assertEquals(null, $post->slug);
     }
 
     /**
@@ -779,8 +778,8 @@ class SluggableTest extends TestCase
 
         $post = new Post(['title' => 'My Test Post']);
         $post->save();
-        $this->assertEquals($post->slug, 'my-test-post');
-        $this->assertEquals($post->subtitle, 'I have been slugged!');
+        $this->assertEquals('my-test-post', $post->slug);
+        $this->assertEquals('I have been slugged!', $post->subtitle);
     }
 
     /**


### PR DESCRIPTION
This PR allows a user to generate a unique slug without ever having a model. This is done by calling `Model::createSlug('Your Title')`.

One example use case for this would be when you want to show a user a preview of the slug that will appear. Most likely, that's something which would be called over AJAX or similar to provide instant response to input. 