### PR TITLE
Bug when using magic getters.

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -23,7 +23,7 @@ trait SluggableTrait
         $save_to = $config['save_to'];
         $on_update = $config['on_update'];
 
-        if (empty($this->{$save_to})) {
+        if (empty($this->attributes[$save_to])) {
             return true;
         }
 


### PR DESCRIPTION
My model has the create method overridden. The event listener fires the sluggify and it doesn't seem to like empty() being called on the magic getter. However this fixed the issue.

The only possible side effect is if someone has created a getSlugAttribute() mutator, but this would be undesirable anyway as the slug should be saved in a queryable / searchable state. Ie processed on save not on retrieval.