### PR TITLE
Tidy test code

### DIFF
--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -17,11 +17,8 @@ class SluggableTest extends TestCase
     {
         parent::setUp();
 
-        // Create an artisan object for calling migrations
-        $artisan = $this->app->make('Illuminate\Contracts\Console\Kernel');
-
         // Call migrations specific to our tests, e.g. to seed the db
-        $artisan->call('migrate', [
+        $this->artisan('migrate', [
           '--database' => 'testbench',
           '--path' => '../tests/database/migrations',
         ]);

--- a/tests/SluggableTest.php
+++ b/tests/SluggableTest.php
@@ -51,7 +51,7 @@ class SluggableTest extends TestCase
      */
     protected function getPackageProviders($app)
     {
-        return ['Cviebrock\EloquentSluggable\SluggableServiceProvider'];
+        return [Cviebrock\EloquentSluggable\SluggableServiceProvider::class];
     }
 
     /**
@@ -444,7 +444,7 @@ class SluggableTest extends TestCase
             Post::findBySlugOrFail('my-fourth-post');
             $this->fail('Not found exception not raised');
         } catch (Exception $e) {
-            $this->assertInstanceOf('Illuminate\Database\Eloquent\ModelNotFoundException',
+            $this->assertInstanceOf(Illuminate\Database\Eloquent\ModelNotFoundException::class,
               $e);
         }
     }
@@ -615,7 +615,7 @@ class SluggableTest extends TestCase
             Post::findBySlugOrFail('my-fourth-post');
             $this->fail('Not found exception not raised');
         } catch (Exception $e) {
-            $this->assertInstanceOf('Illuminate\Database\Eloquent\ModelNotFoundException',
+            $this->assertInstanceOf(Illuminate\Database\Eloquent\ModelNotFoundException::class,
               $e);
         }
     }


### PR DESCRIPTION
Just a few adjustments:

- Streamline migrate call.
- Use `::class` selectors instead of strings, so IDEs can interpret the code better.