### PR TITLE
Import 'Illuminate\Database\Eloquent\Model' to fix phpdoc

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -1,6 +1,7 @@
 <?php namespace Cviebrock\EloquentSluggable;
 
 use Cocur\Slugify\Slugify;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 /**


### PR DESCRIPTION
Without this IDEs assume the output of methods like `findBySlug()` as `Cviebrock\EloquentSluggable\Model`