### PR TITLE
Support Laravel 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - redis-server
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=5.5.9",
     "illuminate/config": "5.*",
     "illuminate/database": "5.*",
     "illuminate/support": "5.*",

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     "illuminate/config": "5.*",
     "illuminate/database": "5.*",
     "illuminate/support": "5.*",
-    "cocur/slugify": "1.1.*"
+    "cocur/slugify": "~1.4"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",
-    "orchestra/testbench": "3.0.*"
+    "orchestra/testbench": "~3.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/config": "5.*",
-    "illuminate/database": "5.*",
-    "illuminate/support": "5.*",
+    "illuminate/config": "~5.2",
+    "illuminate/database": "~5.2",
+    "illuminate/support": "~5.2",
     "cocur/slugify": "~1.4"
   },
   "require-dev": {

--- a/src/SluggableTableCommand.php
+++ b/src/SluggableTableCommand.php
@@ -1,7 +1,7 @@
 <?php namespace Cviebrock\EloquentSluggable;
 
 use Illuminate\Database\Console\Migrations\BaseCommand;
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use Symfony\Component\Console\Input\InputArgument;
 
 /**


### PR DESCRIPTION
Laravel 5.1 deprecated using `bindShared` and 5.2 removed it completely, because of this a package update to `cocur/slugify` is needed to at least 1.4. `orchestra/testbench` 3.0 only supports Laravel 5.0.* so that requires an update as well.

`Illuminate\Foundation\Composer` has been moved to `Illuminate\Support\Composer`