### PR TITLE
dont create a slug if build_from is empty

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -22,7 +22,7 @@ trait SluggableTrait
         $save_to = $config['save_to'];
         $on_update = $config['on_update'];
 
-        if(empty($this->generateSlug($this->$config['build_from']))) {
+        if(empty($this->generateSlug($this->getSlugSource()))) {
             return false;
         }
 

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -22,6 +22,10 @@ trait SluggableTrait
         $save_to = $config['save_to'];
         $on_update = $config['on_update'];
 
+        if(empty($this->generateSlug($this->$config['build_from']))) {
+            return false;
+        }
+
         if (empty($this->attributes[$save_to])) {
             return true;
         }


### PR DESCRIPTION
Described here: https://github.com/cviebrock/eloquent-sluggable/issues/219