### PR TITLE
Update package constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     }
   ],
   "require": {
-    "php": ">=5.5",
-    "illuminate/config": "~5.1|~5.2",
-    "illuminate/database": "~5.1|~5.2",
-    "illuminate/support": "~5.1|~5.2",
+    "php": "^5.5.9 || ^7.0",
+    "illuminate/config": "5.1.* || 5.2.* || 5.3.*",
+    "illuminate/database": "5.1.* || 5.2.* || 5.3.*",
+    "illuminate/support": "5.1.* || 5.2.* || 5.3.*",
     "cocur/slugify": "^1.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.0",
+    "phpunit/phpunit": "^4.8 || ^5.0",
     "orchestra/testbench": "^3.0",
     "mockery/mockery": "^0.9.4"
   },


### PR DESCRIPTION
- Added support for Laravel 5.3 (which is just around the corner)
- Added new recomended constraint syntax


I've also updated the Laravel support constraint since [Laravel doesn't follow [SemVer](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5#.h7rikxacr). Also just a quick note: `~5.1` would cover both `~5.1` and `~5.2`, please [see the documentation](https://getcomposer.org/doc/articles/versions.md#tilde).

Let me know what you think.