### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ Then, update `config/app.php` by adding an entry for the service provider.
 ```php
 'providers' => [
     // ...
-    Cviebrock\EloquentSluggable\ServiceProvider::class,
+    Cviebrock\EloquentSluggable\SluggableServiceProvider::class,
 ];
 ```
 
 Finally, from the command line again, publish the default configuration file:
 
 ```shell
-php artisan vendor:publish --provider="Cviebrock\EloquentSluggable\ServiceProvider"
+php artisan vendor:publish --provider="Cviebrock\EloquentSluggable\SluggableServiceProvider"
 ```
 
 


### PR DESCRIPTION
When i installed via composer. It said that
`Cviebrock\EloquentSluggable\ServiceProvider::class`
did not exist. 

So I looked into it and saw that, 
`Cviebrock\EloquentSluggable\SluggableServiceProvider::class`
 did exist.

I used that and everything ran just fine when doing
`php artisan vendor:publish --provider="Cviebrock\EloquentSluggable\SluggableServiceProvider"`