### PR TITLE
Add automatic route key lookup for URL generator helper functions in Laravel

### DIFF
--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -428,4 +428,14 @@ trait SluggableTrait
 
         return $result;
     }
+
+    /**
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName()
+    {
+        return $this->getSluggableConfig()['save_to'];
+    }
 }

--- a/src/SluggableTrait.php
+++ b/src/SluggableTrait.php
@@ -428,14 +428,4 @@ trait SluggableTrait
 
         return $result;
     }
-
-    /**
-     * Get the route key for the model.
-     *
-     * @return string
-     */
-    public function getRouteKeyName()
-    {
-        return $this->getSluggableConfig()['save_to'];
-    }
 }


### PR DESCRIPTION
This will make URL generators (ie. "route()" method) correctly look up from the slug column instead of the   ID column by overwriting the Eloquent "getRouteKeyName" method. This shouldn't break existing code except for anyone who has already figured this out and might be manually overwriting this method on their sluggable methods, which would result in an easy-to-catch collision error post-update.