### PR TITLE
Add a new (optional) FindBySlug trait

### DIFF
--- a/src/FindBySlug.php
+++ b/src/FindBySlug.php
@@ -1,0 +1,62 @@
+<?php namespace Cviebrock\EloquentSluggable;
+
+use Illuminate\Database\Eloquent\Builder;
+
+trait FindBySlug
+{
+    public function scopeWhereOneOfMySlugs(Builder $query, $slug, $fields = [])
+    {
+        $fields = $this->slugFieldsGuard($query, $fields);
+
+        return $query->where(function ($q) use ($slug, $fields) {
+            foreach ($fields as $column) {
+                $q->orWhere($column, $slug);
+            }
+        });
+    }
+
+    public static function findBySlug($slug, $fields = [])
+    {
+        return static::whereOneOfMySlugs($slug, $fields)->first();
+    }
+
+    public static function findBySlugOrFail($slug, $fields = [])
+    {
+        return static::whereOneOfMySlugs($slug, $fields)->firstOrFail();
+    }
+
+    public static function findBySlugOrId($slugOrId, $fields = [])
+    {
+        $found = is_numeric($slugOrId) ? static::find($slugOrId) : null;
+
+        return ! is_null($found) ? $found: static::whereOneOfMySlugs($slugOrId, $fields)->first();
+    }
+
+    public static function findBySlugOrIdOrFail($slugOrId, $fields = [])
+    {
+        $found = is_numeric($slugOrId) ? static::find($slugOrId) : null;
+
+        return ! is_null($found) ? $found : static::whereOneOfMySlugs($slugOrId, $fields)->firstOrFail();
+    }
+
+    protected function slugFieldsGuard(Builder $query, $fields = [])
+    {
+        $availableSlugFields = array_keys($query->getModel()->sluggable());
+        $fields = (array) $fields;
+
+        if (empty($fields)) {
+            return empty($this->findBySlugDefault()) ? $availableSlugFields: $this->findBySlugDefault();
+        }
+
+        if (! empty($diff = array_diff($fields, $availableSlugFields))) {
+            throw new \InvalidArgumentException('Invalid slugs field(s) ' . implode(', ', $diff));
+        }
+
+        return $fields;
+    }
+
+    protected function findBySlugDefault()
+    {
+        return [];
+    }
+}

--- a/tests/FindBySlugTests.php
+++ b/tests/FindBySlugTests.php
@@ -1,0 +1,107 @@
+<?php namespace Cviebrock\EloquentSluggable\Tests;
+
+use Cviebrock\EloquentSluggable\Tests\Models\Post;
+use Cviebrock\EloquentSluggable\Tests\Models\PostWithMultipleSlugs;
+use Cviebrock\EloquentSluggable\Tests\Models\PostWithMultipleSlugsAndFindByDefault;
+
+/**
+ * Class FindBySlugTests
+ *
+ * @package Tests
+ */
+class FindBySlugTests extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        PostWithMultipleSlugs::create([
+            'title' => 'My Test Post',
+            'subtitle' => 'My Subtitle',
+        ]);
+
+        Post::create([
+            'title' => 'Simple Post'
+        ]);
+    }
+
+    public function testWhereOneOfMySlugs()
+    {
+        $this->assertNotNull(Post::whereOneOfMySlugs('simple-post')->first());
+
+        $this->assertNotNull(PostWithMultipleSlugs::whereOneOfMySlugs('my-test-post')->first());
+        $this->assertNotNull(PostWithMultipleSlugs::whereOneOfMySlugs('my-test-post', 'slug')->first());
+
+        $this->assertNotNull(PostWithMultipleSlugs::whereOneOfMySlugs('my.subtitle')->first());
+        $this->assertNotNull(PostWithMultipleSlugs::whereOneOfMySlugs('my.subtitle', ['dummy'])->first());
+
+        $this->assertNull(PostWithMultipleSlugs::whereOneOfMySlugs('my-test-post', 'dummy')->first());
+    }
+
+    public function testFindBySlug()
+    {
+        $this->assertNotNull(Post::findBySlug('simple-post'));
+
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlug('my-test-post'));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlug('my-test-post', 'slug'));
+
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlug('my.subtitle'));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlug('my.subtitle', 'dummy'));
+
+        $this->assertNull(PostWithMultipleSlugs::findBySlug('my-test-post', 'dummy'));
+    }
+
+    public function testFindBySlugOrFail()
+    {
+        $this->assertNotNull(Post::findBySlugOrFail('simple-post'));
+
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrFail('my-test-post'));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrFail('my.subtitle'));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrFail('my-test-post', 'slug'));
+
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        PostWithMultipleSlugs::findBySlugOrFail('my-test-post', 'dummy');
+    }
+
+    public function testFindBySlugOrId()
+    {
+        $this->assertNotNull(Post::findBySlugOrId(2));
+        $this->assertNotNull(Post::findBySlugOrId('simple-post'));
+
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrId(1));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrId('my-test-post'));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrId('my.subtitle'));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrId('my-test-post', 'slug'));
+
+        $this->assertNull(PostWithMultipleSlugs::findBySlugOrId(5));
+        $this->assertNull(PostWithMultipleSlugs::findBySlugOrId('my-test-post', 'dummy'));
+    }
+
+    public function testFindBySlugOrIdOrFail()
+    {
+        $this->assertNotNull(Post::findBySlugOrIdOrFail(2));
+        $this->assertNotNull(Post::findBySlugOrIdOrFail('simple-post'));
+
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrIdOrFail(1));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrIdOrFail('my-test-post'));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrIdOrFail('my.subtitle'));
+        $this->assertNotNull(PostWithMultipleSlugs::findBySlugOrIdOrFail('my-test-post', 'slug'));
+
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        PostWithMultipleSlugs::findBySlugOrIdOrFail(5);
+
+        $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+        PostWithMultipleSlugs::findBySlugOrIdOrFail('my-test-post', 'dummy');
+    }
+
+    public function testDefaultFieldWasSet()
+    {
+        PostWithMultipleSlugsAndFindByDefault::create([
+            'title' => 'My Test Post',
+            'subtitle' => 'My Subtitle',
+        ]);
+
+        $this->assertNull(PostWithMultipleSlugsAndFindByDefault::findBySlug('my-test-post'));
+        $this->assertNotNull(PostWithMultipleSlugsAndFindByDefault::findBySlug('my.subtitle'));
+    }
+}

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -1,6 +1,7 @@
 <?php namespace Cviebrock\EloquentSluggable\Tests\Models;
 
 use Cviebrock\EloquentSluggable\Sluggable;
+use Cviebrock\EloquentSluggable\FindBySlug;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 class Post extends Model
 {
 
-    use Sluggable;
+    use Sluggable, FindBySlug;
 
     /**
      * The table associated with the model.

--- a/tests/Models/PostWithMultipleSlugsAndFindByDefault.php
+++ b/tests/Models/PostWithMultipleSlugsAndFindByDefault.php
@@ -1,0 +1,31 @@
+<?php namespace Cviebrock\EloquentSluggable\Tests\Models;
+
+/**
+ * Class PostWithMultipleSlugs
+ */
+class PostWithMultipleSlugsAndFindByDefault extends Post
+{
+
+    /**
+     * Return the sluggable configuration array for this model.
+     *
+     * @return array
+     */
+    public function sluggable()
+    {
+        return [
+            'slug' => [
+                'source' => 'title',
+            ],
+            'dummy' => [
+                'source' => 'subtitle',
+                'separator' => '.',
+            ],
+        ];
+    }
+
+    public function findBySlugDefault()
+    {
+        return ['dummy'];
+    }
+}


### PR DESCRIPTION
New trait bringing back familiar methods, with a twist. By default, it
searches each of the slug fields for matching records. However, you can
provide a default slug field, or override on the find methods directly.