### PR TITLE
Preserve connection when checking for existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,9 +362,9 @@ Please use Github for bugs, comments, suggestions.
 	- Add your test methods to `eloquent-sluggable/tests/SluggableTest.php`.
 	- Run `vendor/bin/phpunit` to the new (and all previous) tests and make sure everything passes.
 3. Commit your changes (and your tests) and push to your branch.
-4. Create a new pull request against the eloquent-sluggable `develop` branch.
+4. Create a new pull request against the eloquent-sluggable `2.0` branch.
 
-**Please note that you must create your pull request against the `develop` branch.**
+**Please note that you must create your pull request against the `2.0` branch for fixes to the version compatible with Laravel 4.  If you are working on Laravel 5 support, use the `3.0` branch.**
 
 
 

--- a/src/Cviebrock/EloquentSluggable/SluggableTrait.php
+++ b/src/Cviebrock/EloquentSluggable/SluggableTrait.php
@@ -163,11 +163,10 @@ trait SluggableTrait {
 		$save_to         = $this->sluggable['save_to'];
 		$include_trashed = $this->sluggable['include_trashed'];
 
-		$instance = new static;
-
-		$query = $instance->where( $save_to, 'LIKE', $slug.'%' );
+		$query = $this->newQuery()->where( $save_to, 'LIKE', $slug.'%' );
 
 		// include trashed models if required
+		$instance = new static;
 		if ( $include_trashed && $instance->usesSoftDeleting() )
 		{
 			$query = $query->withTrashed();


### PR DESCRIPTION
If a model instance has had a different database `connection` set, this change looks for existing slugs on THAT connection (the connection where the model actually exists).  Creating the query using a new instance of the model (the previous behavior) would use the default connection.