### PR TITLE
Updated replacement for findBySlugOrIdOrFail in upgrading guideline

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -101,7 +101,7 @@ $post = Post::findBySlugOrIdOrFail($input);
 $posts = Post::where('slug',$input)->get();
 $post = Post::where('slug', $input)->first();
 $post = Post::where('slug', $input)->firstOrFail();
-$post = Post::where('slug', $input)->get() ?: Post::findOrFail((int)$input);
+$post = Post::where('slug', $input)->first() ?: Post::findOrFail((int)$input);
 ```
 
 Alternatively, your model can use the `SluggableScopeHelpers` trait.  


### PR DESCRIPTION
Updated the replacement for the method `findBySlugOrIdOrFail` in the upgrading guideline `UPGRADING.md`. Directly accessing the first and only match via `first` instead `get` should be better for Laravel 5.3 since `get` will return a collection.