### PR TITLE
Primary key not prefixed when using Scopes

### DIFF
--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -331,7 +331,7 @@ class SlugService
         }
 
         // get the list of all matching slugs
-        $results = $query->select([$attribute, $this->model->getKeyName()])
+        $results = $query->select([$attribute, $this->model->getTable() . '.' . $this->model->getKeyName()])
             ->get()
             ->toBase();
 


### PR DESCRIPTION
I was using global scopes however when you apply a scope the system uses an ambiguous `id` field. This should be prefixed with the table now to solve join issues.