### PR TITLE
Allow SlugService to be extended + fix for validateSlug reserved coll…

### DIFF
--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -289,7 +289,7 @@ class SlugService
         } elseif (is_callable($method)) {
             $suffix = call_user_func($method, $slug, $separator, $list);
         } else {
-            throw new \UnexpectedValueException('Sluggable "unigueSuffix" for ' . get_class($this->model) . ':' . $attribute . ' is not null, or a closure.');
+            throw new \UnexpectedValueException('Sluggable "uniqueSuffix" for ' . get_class($this->model) . ':' . $attribute . ' is not null, or a closure.');
         }
 
         return $slug . $separator . $suffix;

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -202,6 +202,7 @@ class SlugService
      */
     protected function validateSlug($slug, array $config, $attribute)
     {
+
         $separator = $config['separator'];
         $reserved = $config['reserved'];
 
@@ -216,13 +217,25 @@ class SlugService
 
         if (is_array($reserved)) {
             if (in_array($slug, $reserved)) {
-                return $slug . $separator . '1';
+
+                $method = $config['uniqueSuffix'];
+                if ($method === null) {
+                    $suffix = $this->generateSuffix($slug, $separator, collect($reserved));
+                } elseif (is_callable($method)) {
+                    $suffix = call_user_func($method, $slug, $separator, collect($reserved));
+                } else {
+                    throw new \UnexpectedValueException('Sluggable "uniqueSuffix" for ' . get_class($this->model) . ':' . $attribute . ' is not null, or a closure.');
+                }
+
+                return $slug . $separator . $suffix;
+
             }
 
             return $slug;
         }
 
         throw new \UnexpectedValueException('Sluggable "reserved" for ' . get_class($this->model) . ':' . $attribute . ' is not null, an array, or a closure that returns null/array.');
+
     }
 
     /**
@@ -276,7 +289,7 @@ class SlugService
         } elseif (is_callable($method)) {
             $suffix = call_user_func($method, $slug, $separator, $list);
         } else {
-            throw new \UnexpectedValueException('Sluggable "reserved" for ' . get_class($this->model) . ':' . $attribute . ' is not null, an array, or a closure that returns null/array.');
+            throw new \UnexpectedValueException('Sluggable "unigueSuffix" for ' . get_class($this->model) . ':' . $attribute . ' is not null, or a closure.');
         }
 
         return $slug . $separator . $suffix;
@@ -368,7 +381,7 @@ class SlugService
         if (is_string($model)) {
             $model = new $model;
         }
-        $instance = (new self())->setModel($model);
+        $instance = (new static())->setModel($model);
 
         if ($config === null) {
             $config = array_get($model->sluggable(), $attribute);

--- a/tests/BaseTests.php
+++ b/tests/BaseTests.php
@@ -131,7 +131,7 @@ class BaseTests extends TestCase
         $post = PostWithReservedSlug::create([
             'title' => 'Add'
         ]);
-        $this->assertEquals('add-1', $post->slug);
+        $this->assertEquals('add-2', $post->slug);
     }
 
     /**

--- a/tests/Models/PostWithReservedSlug.php
+++ b/tests/Models/PostWithReservedSlug.php
@@ -20,7 +20,7 @@ class PostWithReservedSlug extends Post
         return [
             'slug' => [
                 'source' => 'title',
-                'reserved' => ['add']
+                'reserved' => ['add','add-1']
             ]
         ];
     }


### PR DESCRIPTION
call to `new self()` in createSlug prevents easy extension of this class despite all methods being public/protected, change to `new static()` fixes this.

validateSlug can return a reserved slug as suffixing is too simple and does not recheck reserved.
For example if reserved contains `test` and `test-1` then slugging `test` will return `test-1`, a reserved slug, fixed by re-using existing suffixing behaviour.
