### PR TITLE
Add Ideographic Engine

### DIFF
--- a/src/Engines/IdeographicEngine.php
+++ b/src/Engines/IdeographicEngine.php
@@ -1,0 +1,29 @@
+<?php namespace Cviebrock\EloquentSluggable\Engines;
+
+use Cocur\Slugify\SlugifyInterface;
+
+/**
+ * Class IdeographicEngine
+ *
+ * @package Cviebrock\EloquentSluggable\Engines
+ */
+class IdeographicEngine implements SlugifyInterface
+{
+
+
+    /**
+     * For ideographic Engine, Return a unique Random string instead of Slug
+     *
+     * @param string $string
+     * @param string|array|null $options
+     *
+     * @return string
+     *
+     * @api
+     */
+    public function slugify($string, $options = null)
+    {
+        $fullString = md5(uniqid(rand(), true));
+        return substr($fullString, 0, 12);
+    }
+}

--- a/tests/IdeographicEngineTests.php
+++ b/tests/IdeographicEngineTests.php
@@ -1,0 +1,25 @@
+<?php namespace Cviebrock\EloquentSluggable\Tests;
+
+use Cviebrock\EloquentSluggable\Tests\Models\PostWithIdeographicEngine;
+
+
+/**
+ * Class UniqueTests
+ *
+ * @package Tests
+ */
+class IdeographicEngineTests extends TestCase
+{
+
+    /**
+     * Test Ideographic slugging functionality.
+     */
+    public function testIdeographicEngine()
+    {
+        $post = new PostWithIdeographicEngine([
+            'title' => 'The quick brown fox jumps over the lazy dog'
+        ]);
+        $post->save();
+        $this->assertEquals(12, strlen($post->slug));
+    }
+}

--- a/tests/Models/PostWithIdeographicEngine.php
+++ b/tests/Models/PostWithIdeographicEngine.php
@@ -1,0 +1,23 @@
+<?php namespace Cviebrock\EloquentSluggable\Tests\Models;
+
+use Cviebrock\EloquentSluggable\Engines\IdeographicEngine;
+
+
+/**
+ * Class PostWithIdeographicEngine
+ *
+ * A test model that customizes the Slugify engine with custom rules.
+ *
+ * @package Cviebrock\EloquentSluggable\Tests\Models
+ */
+class PostWithIdeographicEngine extends Post
+{
+
+    /**
+     * @return IdeographicEngine
+     */
+    public function customizeSlugEngine()
+    {
+        return new IdeographicEngine();
+    }
+}


### PR DESCRIPTION
When Ideographic language, or unmanage language by Slugify, the slug comes empty. This fix provides an engine that will generate a 12 chars random string.