### PR TITLE
Fixes comma omission between array elements in documentation code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ public function sluggable()
             'source' => 'title'
         ],
         'author-slug' => [
-            'source' => ['author.lastname', 'author.firstname']
+            'source' => ['author.lastname', 'author.firstname'],
             'separator' => '_'
         ],
     ];


### PR DESCRIPTION
Just noticed the comma omission in this section of the documentation.

```
public function sluggable()
{
    return [
        'title-slug' => [
            'source' => 'title'
        ],
        'author-slug' => [
            'source' => ['author.lastname', 'author.firstname']
            'separator' => '_'
        ],
    ];
}
```
**Thank you!**
