### PR TITLE
[WIP] Remember Previously Used Slugs

### DIFF
--- a/src/Middleware/RedirectOnOldSlug.php
+++ b/src/Middleware/RedirectOnOldSlug.php
@@ -1,0 +1,49 @@
+<?php namespace Cviebrock\EloquentSluggable\Middleware;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\RouteUrlGenerator;
+use Illuminate\Support\Facades\DB;
+
+class RedirectOnOldSlug
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure                 $next
+     *
+     * @return mixed
+     * @throws \Illuminate\Routing\Exceptions\UrlGenerationException
+     */
+    public function handle(Request $request, \Closure $next)
+    {
+        $route = $request->route();
+        if ($oldSlug = $this->findOldSlug($route->parameter('slug'))) {
+            $currentSlug = $this->findSlugFrom($oldSlug);
+            $path = $this->routeGenerator($request)->to(
+                $request->route(),
+                array_merge($route->parameters(), ['slug' => $currentSlug])
+            );
+
+            return new RedirectResponse($path);
+        }
+
+        return $next($request);
+    }
+
+    private function findOldSlug($slug)
+    {
+        return DB::table('old_slugs')->where('slug', $slug)->first();
+    }
+
+    private function findSlugFrom($oldSlug)
+    {
+        return app($oldSlug->model)->find($oldSlug->entity_id)->slug;
+    }
+
+    private function routeGenerator($request)
+    {
+        return new RouteUrlGenerator(app('url'), $request);
+    }
+}

--- a/tests/Middleware/RedirectOnOldSlugTest.php
+++ b/tests/Middleware/RedirectOnOldSlugTest.php
@@ -1,0 +1,59 @@
+<?php namespace Cviebrock\EloquentSluggable\Tests\Middleware;
+
+use Cviebrock\EloquentSluggable\Middleware\RedirectOnOldSlug;
+use Cviebrock\EloquentSluggable\Tests\Models\Post;
+use Cviebrock\EloquentSluggable\Tests\TestCase;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\DB;
+
+class RedirectOnOldSlugTest extends TestCase
+{
+    public function testRedirectsToCurrentSlug()
+    {
+        $middleware = new RedirectOnOldSlug;
+
+        $post = Post::create([
+            'title' => 'the current slug',
+        ]);
+        DB::table('old_slugs')->insert([
+            'model' => Post::class,
+            'entity_id' => $post->id,
+            'slug' => 'some-old-slug',
+        ]);
+
+        $request = Request::create('/path/to/some-old-slug');
+        $request->setRouteResolver(function () use ($request) {
+            return tap(new Route(['GET'], '/path/to/{slug}', function () {}), function ($route) use ($request) {
+                $route->bind($request);
+            });
+        });
+
+        $response = $middleware->handle($request, function () {});
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertEquals('/path/to/the-current-slug', $response->getTargetUrl());
+    }
+
+    public function testPassesRequestToNextMiddleWareOnOldSlugMiss()
+    {
+        $middleware = new RedirectOnOldSlug;
+
+        $passed = false;
+        $nextCallback = function () use (&$passed) {
+            $passed = true;
+        };
+
+        $request = Request::create('/path/to/not-a-slug');
+        $request->setRouteResolver(function () use ($request) {
+            return tap(new Route(['GET'], '/path/to/{slug}', function () {}), function ($route) use ($request) {
+                $route->bind($request);
+            });
+        });
+
+        $middleware->handle($request, $nextCallback);
+
+        $this->assertTrue($passed);
+    }
+}

--- a/tests/database/migrations/2018_03_07_032532_old_slugs.php
+++ b/tests/database/migrations/2018_03_07_032532_old_slugs.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+
+/**
+ * Class OldSlugs
+ */
+class OldSlugs extends Migration
+{
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('old_slugs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('model');
+            $table->string('entity_id');
+            $table->string('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('old_slugs');
+    }
+}


### PR DESCRIPTION
Referencing [Issue #328](https://github.com/cviebrock/eloquent-sluggable/issues/328), this is just a first pass (and incomplete) at attempting to remember previous slugs for slugged entities. 

I hope to use this PR more so as an RFC on the approach I took and to test whether this is a viable feature.

This is what I think the package will need to complete this feature

- [ ] an option in the config to turn this feature on or off (possibly a set of options to configure the behaviour of the feature)
- [ ] a new database table to store previously used slugs
- [ ] a model listener for the `slugging` event to capture the existing slug and move it to the `old_slugs` table
 - [ ] a middleware to intercept requests asking for old slugs and redirecting to the current slug
 - [ ] some rules regarding what to do if slugs collide in the `old_slugs` table
 - [ ] updates to the Service Provider to publish the new migration
 - [ ] documentation

Currently, all I've implemented is a rough draft of the middleware which redirects requests to old slugs. Honestly, I'm not crazy that this is implemented as a "before" middleware, in that, old slugs are taking precedence over current slugs but in order for this to work as an "after" middleware, I'd have to hook into the ExceptionHandler somehow and I'm not sure if you can do that or not (I'll have to check). 

Let me know what you think.

Thank you for helping to make this package better!

Please make sure you've read [CONTRIBUTING.md](https://github.com/cviebrock/eloquent-sluggable/blob/master/CONTRIBUTING.md) 
before submitting your pull request, and that you have:

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [x] added tests
- [ ] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [ ] only submitted one pull request per feature

**Thank you!**
