### PR TITLE
Update to support Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "require-dev": {
         "codedungeon/phpunit-result-printer": "^0.19.6",
         "mockery/mockery": "^0.9.4",
-        "orchestra/database": "~3.6.0",
-        "orchestra/testbench": "~3.6.0",
+        "orchestra/database": "3.7.x-dev",
+        "orchestra/testbench": "v3.7.0",
         "phpunit/phpunit": "~7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "require": {
         "php": "^7.0",
         "cocur/slugify": "^3.1",
-        "illuminate/config": "~5.6.0",
-        "illuminate/database": "~5.6.0",
-        "illuminate/support": "~5.6.0"
+        "illuminate/config": "~5.7.0",
+        "illuminate/database": "~5.7.0",
+        "illuminate/support": "~5.7.0"
     },
     "require-dev": {
         "codedungeon/phpunit-result-printer": "^0.19.6",


### PR DESCRIPTION
Changes to support Laravel 5.7
Change to requirement of Orchestra/Database to use a version that supports Laravel 5.7
No Tests added/needed
May need to be updated once Orchestra/Database has a newly tagged version for Laravel 5.7