### PR TITLE
fix slug gets null if model is updated with no source column loaded

### DIFF
--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -41,9 +41,10 @@ class SlugService
 
             $slug = $this->buildSlug($attribute, $config, $force);
 
-            $this->model->setAttribute($attribute, $slug);
-
-            $attributes[] = $attribute;
+            if ($slug !== null) {
+                $this->model->setAttribute($attribute, $slug);
+                $attributes[] = $attribute;
+            }
         }
 
         return $this->model->isDirty($attributes);

--- a/tests/OnUpdateTests.php
+++ b/tests/OnUpdateTests.php
@@ -104,4 +104,24 @@ class OnUpdateTests extends TestCase
         ]);
         $this->assertEquals('my-first-post-3', $post3->slug);
     }
+
+    /**
+     * Test that the slug isn't set to null if the source fields
+     * not loaded in model.
+     */
+    public function testSlugDoesNotChangeIfSourceNotProvidedInModel()
+    {
+        $post = Post::create([
+            'title' => 'My First Post'
+        ]);
+        $this->assertEquals('my-first-post', $post->slug);
+
+        $post = Post::whereKey($post->id)->get(['id','subtitle'])->first();
+        $post->update([
+            'subtitle' => 'A Subtitle'
+        ]);
+
+        $post = Post::findOrFail($post->id);
+        $this->assertEquals('my-first-post', $post->slug);
+    }
 }


### PR DESCRIPTION
Fixed a bug where slug set to null when model is loaded without the source column.

Test was created not sure if is in the proper test file.