### PR TITLE
4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/
 composer.lock
 composer.phar
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,23 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+
+env:
+  - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+  - COMPOSER_FLAGS=""
 
 matrix:
-  include:
-    - php: 5.6
-      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+  exclude:
+    - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction --dev $PREFER_LOWEST
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
   - travis_retry composer dump-autoload
 
 script:
-  - vendor/bin/phpunit
+  - php vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ automatically, with minimal configuration.
 > |       4.x       |        2.x        |
 > |     5.1, 5.2    |        4.0        |
 > | 5.1†, 5.2†, 5.3 |        4.1        |
-> |       5.4       |       4.2.1‡      |
+> |       5.4       |      ~4.2.1‡      |
 >
 > † The 4.1 version _should_ work with Laravel 5.1 and 5.2, but might not in the future.
 >
-> ‡ The 4.2.0 version was short-lived and had some issues; please upgrade to 4.2.1
+> ‡ The 4.2.0 version was short-lived and had some issues; please upgrade to the latest
+> 4.2.* version.
 >
 > Also note that different versions of the package have different configuration
 > settings.  See [UPGRADING.md](UPGRADING.md) for details.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ automatically, with minimal configuration.
 First, you'll need to install the package via Composer:
 
 ```shell
-$ composer require cviebrock/eloquent-sluggable
+$ composer require cviebrock/eloquent-sluggable:^4.2
 ```
 
 Then, update `config/app.php` by adding an entry for the service provider.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ class Post extends Model
 ```
 
 Of course, your model and database will need a column in which to store the slug. 
-You will need to add this manually via a migration.
+You can use `slug` or any other appropriate name you want; your configuration array
+will determine to which field the data will be stored.  You will need to add the 
+column manually via your own migration.
 
 (Previous versions of the package included an `artisan sluggable:table` command to
 assist you.  This has been deprecated because it's easy enough to generate your own

--- a/composer.json
+++ b/composer.json
@@ -40,13 +40,6 @@
     "scripts": {
         "test": "phpunit"
     },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Cviebrock\\EloquentSluggable\\ServiceProvider"
-            ]
-        }
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -271,15 +271,18 @@ class SlugService
         // if our slug is in the list, but
         // 	a) it's for our model, or
         //  b) it looks like a suffixed version of our slug
+        //  c) it's not empty
         // ... we are also okay (use the current slug)
-        if ($list->has($this->model->getKey())) {
-            $currentSlug = $list->get($this->model->getKey());
+        if ($this->model->{$attribute}) {
+            if ($list->has($this->model->getKey())) {
+                $currentSlug = $list->get($this->model->getKey());
 
-            if (
-                $currentSlug === $slug ||
-                strpos($currentSlug, $slug) === 0
-            ) {
-                return $currentSlug;
+                if (
+                    $currentSlug === $slug ||
+                    strpos($currentSlug, $slug) === 0
+                ) {
+                    return $currentSlug;
+                }
             }
         }
 

--- a/tests/OnUpdateTests.php
+++ b/tests/OnUpdateTests.php
@@ -104,4 +104,23 @@ class OnUpdateTests extends TestCase
         ]);
         $this->assertEquals('my-first-post-3', $post3->slug);
     }
+
+    public function testSlugRegenerateAfterModelCreated()
+    {
+        $post1 = Post::create([
+            'title' => 'A post title'
+        ]);
+        $this->assertEquals('a-post-title', $post1->slug);
+
+        $post2 = new Post;
+        $post2->title = $post1->title;
+        $post2->slug = $post1->slug;
+        $post2->save();
+
+        $post2->title = 'A post title';
+        $post2->slug = '';
+        $post2->save();
+
+        $this->assertEquals('a-post-title-1', $post2->slug);
+    }
 }


### PR DESCRIPTION
When slug field is editable for users, there is no way to regenerate slug if the model already exists

I suggest when clearing the field in form generate the slug again
