### PR TITLE
Regenerate slug after model was created (4.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/
 composer.lock
 composer.phar
+.idea

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -284,15 +284,18 @@ class SlugService
         // if our slug is in the list, but
         // 	a) it's for our model, or
         //  b) it looks like a suffixed version of our slug
+        //  c) it's not empty
         // ... we are also okay (use the current slug)
-        if ($list->has($this->model->getKey())) {
-            $currentSlug = $list->get($this->model->getKey());
+        if ($this->model->{$attribute}) {
+            if ($list->has($this->model->getKey())) {
+                $currentSlug = $list->get($this->model->getKey());
 
-            if (
-                $currentSlug === $slug ||
-                strpos($currentSlug, $slug) === 0
-            ) {
-                return $currentSlug;
+                if (
+                    $currentSlug === $slug ||
+                    strpos($currentSlug, $slug) === 0
+                ) {
+                    return $currentSlug;
+                }
             }
         }
 

--- a/tests/OnUpdateTests.php
+++ b/tests/OnUpdateTests.php
@@ -104,4 +104,23 @@ class OnUpdateTests extends TestCase
         ]);
         $this->assertEquals('my-first-post-3', $post3->slug);
     }
+
+    public function testSlugRegenerateAfterModelCreated()
+    {
+        $post1 = Post::create([
+            'title' => 'A post title'
+        ]);
+        $this->assertEquals('a-post-title', $post1->slug);
+
+        $post2 = new Post;
+        $post2->title = $post1->title;
+        $post2->slug = $post1->slug;
+        $post2->save();
+
+        $post2->title = 'A post title';
+        $post2->slug = '';
+        $post2->save();
+
+        $this->assertEquals('a-post-title-1', $post2->slug);
+    }
 }


### PR DESCRIPTION
When slug field is editable for users, there is no way to regenerate slug if the model already exists

I suggest when clearing the field in form generate the slug again