### PR TITLE
Update SlugService.php

### DIFF
--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -292,7 +292,7 @@ class SlugService
 
             if (
                 $currentSlug === $slug ||
-                strpos($currentSlug, $slug) === 0
+                !$slug || strpos($currentSlug, $slug) === 0
             ) {
                 return $currentSlug;
             }


### PR DESCRIPTION
This is a fix for https://github.com/cviebrock/eloquent-sluggable/issues/403

When you try to regenerate a slug for a model where the sluggable fields are empty, and there is already another model with the '' slug.