### PR TITLE
Fixed the path of the sluggable.php config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Configuration was designed to be as flexible as possible. You can set up default
 for all of your Eloquent models, and then override those settings for individual 
 models.
 
-By default, global configuration is set in the `app/config/sluggable.php` file. 
+By default, global configuration is set in the `config/sluggable.php` file. 
 If a configuration isn't set, then the package defaults are used. 
 Here is an example configuration, with all the default settings shown:
 
@@ -507,7 +507,7 @@ public function sluggable() {
 }
 ```
 
-This will use all the default options from `app/config/sluggable.php`, use the model's
+This will use all the default options from `config/sluggable.php`, use the model's
 `__toString()` method as the source, and store the slug in the `slug` field.
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,7 +18,7 @@
 
 The configuration array has changed slightly between versions:
 
-* In your `app/config/sluggable.php` configuration file, remove the `save_to`  
+* In your `config/sluggable.php` configuration file, remove the `save_to`  
   parameter as it is no longer used.  Rename `build_from` to `source`, and convert the other
   parameters from snake_case to lower camelCase (e.g. `include_trashed` -> `includeTrashed`).
 * Your models no longer need to implement `Cviebrock\EloquentSluggable\SluggableInterface`.


### PR DESCRIPTION
This are one on my first pull request, I hope I'm doing well.

The correct path of the sluggable.php config file is `config/sluggable.php` instead of `app/config/sluggable.php`

Thank you for helping to make this package better!

Please make sure you've read [CONTRIBUTING.md](https://github.com/cviebrock/eloquent-sluggable/blob/master/CONTRIBUTING.md) 
before submitting your pull request, and that you have:

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [x] added tests
- [x] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [x] only submitted one pull request per feature

**Thank you!**
