### PR TITLE
Update SlugService.php

### DIFF
--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -138,7 +138,7 @@ class SlugService
             return $value;
         }, (array) $from);
 
-        return implode($sourceStrings, ' ');
+        return implode(' ', $sourceStrings);
     }
 
     /**


### PR DESCRIPTION
Since php 7.4 beta 1, implode has strict order for glue and array.