### PR TITLE
Using a custom field separator

### DIFF
--- a/resources/config/sluggable.php
+++ b/resources/config/sluggable.php
@@ -68,6 +68,12 @@ return [
     'separator' => '-',
 
     /**
+     * Separator between multiple fields. Defaults to a slash.
+     */
+    
+    'field_separator' => '/',
+
+    /**
      * Enforce uniqueness of slugs?  Defaults to true.
      * If a generated slug already exists, an incremental numeric
      * value will be appended to the end until a unique slug is found.  e.g.:


### PR DESCRIPTION
This allows to specify a custom field separator between sources defined in model's ```sluggable()``` method.

The main use case is to generate slugs for nested models, such as folders or categories, but can be used for anything having more than one source field.

Nothing changes compared to before, except when you define multiple sources:

```
public function sluggable()
{
    return [
        'slug' => [
            'source' => ['parent_slug', 'name'],
            'field_separator' => '/'
        ],
    ];
}
```

Now, ```parent_slug``` and ```name``` will be separated by a customisable character (by default, "/"). Generated slug could look like that:

```
/blog/development/web/php/my_cool_post
```

The *field_separator* can be customised in the _config/sluggable.php_ file, or directly in the model as shown above. 