### PR TITLE
Custom field separator

### DIFF
--- a/resources/config/sluggable.php
+++ b/resources/config/sluggable.php
@@ -68,6 +68,12 @@ return [
     'separator' => '-',
 
     /**
+     * Separator between multiple fields. Defaults to a slash.
+     */
+    
+    'field_separator' => '/',
+
+    /**
      * Enforce uniqueness of slugs?  Defaults to true.
      * If a generated slug already exists, an incremental numeric
      * value will be appended to the end until a unique slug is found.  e.g.:

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,46 +1,473 @@
-<?php namespace Cviebrock\EloquentSluggable;
+<?php namespace Cviebrock\EloquentSluggable\Services;
 
-use Cviebrock\EloquentSluggable\Services\SlugService;
-use Illuminate\Foundation\Application as LaravelApplication;
-use Illuminate\Support\ServiceProvider as BaseServiceProvider;
-use Laravel\Lumen\Application as LumenApplication;
+use Cocur\Slugify\Slugify;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 /**
- * Class ServiceProvider
+ * Class SlugService
  *
- * @package Cviebrock\EloquentSluggable
+ * @package Cviebrock\EloquentSluggable\Services
  */
-class ServiceProvider extends BaseServiceProvider
+class SlugService
 {
 
     /**
-     * Bootstrap the application services.
+     * @var \Illuminate\Database\Eloquent\Model;
      */
-    public function boot()
+    protected $model;
+
+    /**
+     * Slug the current model.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param bool $force
+     *
+     * @return bool
+     */
+    public function slug(Model $model, bool $force = false): bool
     {
-        $this->setUpConfig();
+        $this->setModel($model);
+
+        $attributes = [];
+
+        foreach ($this->model->sluggable() as $attribute => $config) {
+            if (is_numeric($attribute)) {
+                $attribute = $config;
+                $config    = $this->getConfiguration();
+            } else {
+                $config = $this->getConfiguration($config);
+            }
+
+            $slug = $this->buildSlug($attribute, $config, $force);
+
+            if ($slug !== null) {
+                $this->model->setAttribute($attribute, $slug);
+                $attributes[] = $attribute;
+            }
+        }
+
+        return $this->model->isDirty($attributes);
     }
 
     /**
-     * Register the application services.
+     * Get the sluggable configuration for the current model,
+     * including default values where not specified.
+     *
+     * @param array $overrides
+     *
+     * @return array
      */
-    public function register()
+    public function getConfiguration(array $overrides = []): array
     {
-        $this->app->singleton(SluggableObserver::class, function($app) {
-            return new SluggableObserver(new SlugService(), $app['events']);
-        });
+        $defaultConfig = config('sluggable', []);
+
+        return array_merge($defaultConfig, $overrides);
     }
 
-    protected function setUpConfig()
+    /**
+     * Build the slug for the given attribute of the current model.
+     *
+     * @param string $attribute
+     * @param array $config
+     * @param bool $force
+     *
+     * @return null|string
+     */
+    public function buildSlug(string $attribute, array $config, bool $force = null)
     {
-        $source = dirname(__DIR__) . '/resources/config/sluggable.php';
+        $slug = null;
 
-        if ($this->app instanceof LaravelApplication) {
-            $this->publishes([$source => config_path('sluggable.php')], 'config');
-        } elseif ($this->app instanceof LumenApplication) {
-            $this->app->configure('sluggable');
+        if ($force || $this->needsSlugging($attribute, $config)) {
+            $sources = $this->getSlugSources($config['source']);
+
+            if (is_array($sources) && !empty($sources)) {
+                $slugs = [];
+
+                foreach ($sources as $index => $slug) {
+                    if (!$slug && !is_numeric($slug)) {
+                        continue;
+                    }
+
+                    // If the source already contains the field separator char,
+                    // we will split the string and generate a slug for each
+                    // substring before concatenating them again using the field
+                    // separator char
+                    if (strpos($slug, $config['field_separator']) !== false) {
+                        $parts = explode($config['field_separator'], $slug);
+                        $slugParts = array_map(function($value) use ($config, $attribute) {
+                            $s = $this->generateSlug($value, $config, $attribute);
+                            $s = $this->validateSlug($s, $config, $attribute);
+
+                            return $s;
+                        }, $parts);
+
+                        $slug = implode($config['field_separator'], $slugParts);
+                    } else {
+                        $slug = $this->generateSlug($slug, $config, $attribute);
+                        $slug = $this->validateSlug($slug, $config, $attribute);
+                    }
+
+                    // We only need to make the last part of the slug unique
+                    if ($index === count($sources) - 1) {
+                        $slug = $this->makeSlugUnique($slug, $config, $attribute);
+                    }
+
+                    $slugs[] = $slug;
+                }
+
+                $slug = implode($config['field_separator'], $slugs);
+            }
+
+            if($slug === '') {
+                return null;
+            }
         }
 
-        $this->mergeConfigFrom($source, 'sluggable');
+        return $slug;
+    }
+
+    /**
+     * Determines whether the model needs slugging.
+     *
+     * @param string $attribute
+     * @param array $config
+     *
+     * @return bool
+     */
+    protected function needsSlugging(string $attribute, array $config): bool
+    {
+        if (
+            $config['onUpdate'] === true ||
+            empty($this->model->getAttributeValue($attribute))
+        ) {
+            return true;
+        }
+
+        if ($this->model->isDirty($attribute)) {
+            return false;
+        }
+
+        return (!$this->model->exists);
+    }
+
+    /**
+     * Get the source strings for the slug.
+     *
+     * @param mixed $from
+     *
+     * @return array
+     */
+    protected function getSlugSources($from): array
+    {
+        if (is_null($from)) {
+            return [$this->model->__toString()];
+        }
+
+        $sourceStrings = array_map(function ($key) {
+            $value = data_get($this->model, $key);
+            if (is_bool($value)) {
+                $value = (int) $value;
+            }
+
+            return $value;
+        }, (array) $from);
+
+        return $sourceStrings;
+    }
+
+    /**
+     * Generate a slug from the given source string.
+     *
+     * @param string $source
+     * @param array $config
+     * @param string $attribute
+     *
+     * @return string
+     * @throws \UnexpectedValueException
+     */
+    protected function generateSlug(string $source, array $config, string $attribute): string
+    {
+        $separator          = $config['separator'];
+        $method             = $config['method'];
+        $maxLength          = $config['maxLength'];
+        $maxLengthKeepWords = $config['maxLengthKeepWords'];
+
+        if ($method === null) {
+            $slugEngine = $this->getSlugEngine($attribute);
+            $slug       = $slugEngine->slugify($source, $separator);
+        } elseif (is_callable($method)) {
+            $slug = call_user_func($method, $source, $separator);
+        } else {
+            throw new \UnexpectedValueException('Sluggable "method" for ' . get_class($this->model) . ':' . $attribute . ' is not callable nor null.');
+        }
+
+        $len = mb_strlen($slug);
+        if (is_string($slug) && $maxLength && $len > $maxLength) {
+            $reverseOffset    = $maxLength - $len;
+            $lastSeparatorPos = mb_strrpos($slug, $separator, $reverseOffset);
+            if ($maxLengthKeepWords && $lastSeparatorPos !== false) {
+                $slug = mb_substr($slug, 0, $lastSeparatorPos);
+            } else {
+                $slug = trim(mb_substr($slug, 0, $maxLength), $separator);
+            }
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Return a class that has a `slugify()` method, used to convert
+     * strings into slugs.
+     *
+     * @param string $attribute
+     *
+     * @return \Cocur\Slugify\Slugify
+     */
+    protected function getSlugEngine(string $attribute): Slugify
+    {
+        static $slugEngines = [];
+
+        $key = get_class($this->model) . '.' . $attribute;
+
+        if (!array_key_exists($key, $slugEngines)) {
+            $engine = new Slugify();
+            if (method_exists($this->model, 'customizeSlugEngine')) {
+                $engine = $this->model->customizeSlugEngine($engine, $attribute);
+            }
+
+            $slugEngines[$key] = $engine;
+        }
+
+        return $slugEngines[$key];
+    }
+
+    /**
+     * Checks that the given slug is not a reserved word.
+     *
+     * @param string $slug
+     * @param array $config
+     * @param string $attribute
+     *
+     * @return string
+     * @throws \UnexpectedValueException
+     */
+    protected function validateSlug(string $slug, array $config, string $attribute): string
+    {
+        $separator = $config['separator'];
+        $reserved  = $config['reserved'];
+
+        if ($reserved === null) {
+            return $slug;
+        }
+
+        // check for reserved names
+        if ($reserved instanceof \Closure) {
+            $reserved = $reserved($this->model);
+        }
+
+        if (is_array($reserved)) {
+            if (in_array($slug, $reserved)) {
+                $method = $config['uniqueSuffix'];
+                if ($method === null) {
+                    $suffix = $this->generateSuffix($slug, $separator, collect($reserved));
+                } elseif (is_callable($method)) {
+                    $suffix = $method($slug, $separator, collect($reserved));
+                } else {
+                    throw new \UnexpectedValueException('Sluggable "uniqueSuffix" for ' . get_class($this->model) . ':' . $attribute . ' is not null, or a closure.');
+                }
+
+                return $slug . $separator . $suffix;
+            }
+
+            return $slug;
+        }
+
+        throw new \UnexpectedValueException('Sluggable "reserved" for ' . get_class($this->model) . ':' . $attribute . ' is not null, an array, or a closure that returns null/array.');
+    }
+
+    /**
+     * Checks if the slug should be unique, and makes it so if needed.
+     *
+     * @param string $slug
+     * @param array $config
+     * @param string $attribute
+     *
+     * @return string
+     * @throws \UnexpectedValueException
+     */
+    protected function makeSlugUnique(string $slug, array $config, string $attribute): string
+    {
+        if (!$config['unique']) {
+            return $slug;
+        }
+
+        $separator = $config['separator'];
+
+        // find all models where the slug is like the current one
+        $list = $this->getExistingSlugs($slug, $attribute, $config);
+
+        // if ...
+        //     a) the list is empty, or
+        //     b) our slug isn't in the list
+        // ... we are okay
+        if (
+            $list->count() === 0 ||
+            $list->contains($slug) === false
+        ) {
+            return $slug;
+        }
+
+        // if our slug is in the list, but
+        //     a) it's for our model, or
+        //  b) it looks like a suffixed version of our slug
+        // ... we are also okay (use the current slug)
+        if ($list->has($this->model->getKey())) {
+            $currentSlug = $list->get($this->model->getKey());
+
+            if (
+                $currentSlug === $slug ||
+                !$slug || strpos($currentSlug, $slug) === 0
+            ) {
+                return $currentSlug;
+            }
+        }
+
+        $method = $config['uniqueSuffix'];
+        if ($method === null) {
+            $suffix = $this->generateSuffix($slug, $separator, $list);
+        } elseif (is_callable($method)) {
+            $suffix = $method($slug, $separator, $list);
+        } else {
+            throw new \UnexpectedValueException('Sluggable "uniqueSuffix" for ' . get_class($this->model) . ':' . $attribute . ' is not null, or a closure.');
+        }
+
+        return $slug . $separator . $suffix;
+    }
+
+    /**
+     * Generate a unique suffix for the given slug (and list of existing, "similar" slugs.
+     *
+     * @param string $slug
+     * @param string $separator
+     * @param \Illuminate\Support\Collection $list
+     *
+     * @return string
+     */
+    protected function generateSuffix(string $slug, string $separator, Collection $list): string
+    {
+        $len = strlen($slug . $separator);
+
+        // If the slug already exists, but belongs to
+        // our model, return the current suffix.
+        if ($list->search($slug) === $this->model->getKey()) {
+            $suffix = explode($separator, $slug);
+
+            return end($suffix);
+        }
+
+        $list->transform(function ($value, $key) use ($len) {
+            return (int) substr($value, $len);
+        });
+
+        // find the highest value and return one greater.
+        return $list->max() + 1;
+    }
+
+    /**
+     * Get all existing slugs that are similar to the given slug.
+     *
+     * @param string $slug
+     * @param string $attribute
+     * @param array $config
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getExistingSlugs(string $slug, string $attribute, array $config): Collection
+    {
+        $includeTrashed = $config['includeTrashed'];
+
+        $query = $this->model->newQuery()
+            ->findSimilarSlugs($attribute, $config, $slug);
+
+        // use the model scope to find similar slugs
+        if (method_exists($this->model, 'scopeWithUniqueSlugConstraints')) {
+            $query->withUniqueSlugConstraints($this->model, $attribute, $config, $slug);
+        }
+
+        // include trashed models if required
+        if ($includeTrashed && $this->usesSoftDeleting()) {
+            $query->withTrashed();
+        }
+
+        // get the list of all matching slugs
+        $results = $query->select([$attribute, $this->model->getQualifiedKeyName()])
+            ->get()
+            ->toBase();
+
+        // key the results and return
+        return $results->pluck($attribute, $this->model->getKeyName());
+    }
+
+    /**
+     * Does this model use softDeleting?
+     *
+     * @return bool
+     */
+    protected function usesSoftDeleting(): bool
+    {
+        return method_exists($this->model, 'bootSoftDeletes');
+    }
+
+    /**
+     * Generate a unique slug for a given string.
+     *
+     * @param \Illuminate\Database\Eloquent\Model|string $model
+     * @param string $attribute
+     * @param string $fromString
+     * @param array|null $config
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     * @throws \UnexpectedValueException
+     */
+    public static function createSlug($model, string $attribute, string $fromString, array $config = null): string
+    {
+        if (is_string($model)) {
+            $model = new $model;
+        }
+        /** @var static $instance */
+        $instance = (new static())->setModel($model);
+
+        if ($config === null) {
+            $config = Arr::get($model->sluggable(), $attribute);
+            if ($config === null) {
+                $modelClass = get_class($model);
+                throw new \InvalidArgumentException("Argument 2 passed to SlugService::createSlug ['{$attribute}'] is not a valid slug attribute for model {$modelClass}.");
+            }
+        } elseif (!is_array($config)) {
+            throw new \UnexpectedValueException('SlugService::createSlug expects an array or null as the fourth argument; ' . gettype($config) . ' given.');
+        }
+
+        $config = $instance->getConfiguration($config);
+
+        $slug = $instance->generateSlug($fromString, $config, $attribute);
+        $slug = $instance->validateSlug($slug, $config, $attribute);
+        $slug = $instance->makeSlugUnique($slug, $config, $attribute);
+
+        return $slug;
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return $this
+     */
+    public function setModel(Model $model)
+    {
+        $this->model = $model;
+
+        return $this;
     }
 }

--- a/tests/BaseTests.php
+++ b/tests/BaseTests.php
@@ -70,7 +70,7 @@ class BaseTests extends TestCase
             'title' => 'A Post Title',
             'subtitle' => 'A Subtitle'
         ]);
-        $this->assertEquals('a-post-title-a-subtitle', $post->slug);
+        $this->assertEquals('a-post-title/a-subtitle', $post->slug);
     }
 
     public function testLeadingTrailingSpaces()
@@ -325,7 +325,7 @@ class BaseTests extends TestCase
         ]);
         $post->author()->associate($author);
         $post->save();
-        $this->assertEquals('arthur-conan-doyle-first', $post->slug);
+        $this->assertEquals('arthur-conan-doyle/first', $post->slug);
     }
 
     /**
@@ -423,7 +423,7 @@ class BaseTests extends TestCase
         ]);
         $post->save();
 
-        $this->assertEquals('rda-125-15-30-45m3-h-cav', $post->slug);
+        $this->assertEquals('rda-125-15/30/45m3/h-cav', $post->slug);
     }
 
     /**


### PR DESCRIPTION
This allows to specify a custom field separator between sources defined in model's ```sluggable()``` method.

The main use case is to generate slugs for nested models, such as folders or categories, but can be used for anything having more than one source field.

Nothing changes compared to before, except when you define multiple sources:

```
public function sluggable()
{
    return [
        'slug' => [
            'source' => ['parent_slug', 'name'],
            'field_separator' => '/'
        ],
    ];
}
```

Now, ```parent_slug``` and ```name``` will be separated by a customisable character (by default, "/"). Generated slug could look like that:

```
/blog/development/web/php/my_cool_post
```

The *field_separator* can be customised in the _config/sluggable.php_ file, or directly in the model as shown above. 