### PR TITLE
Assert "slugging" against "false", not "null"

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ $slug = SlugService::createSlug(Post::class, 'slug', 'My First Post', ['unique' 
 
 Sluggable models will fire two Eloquent model events: "slugging" and "slugged".
   
-The "slugging" event is fired just before the slug is generated.  If the callback 
-from this event returns false, then the slugging is not performed.
+The "slugging" event is fired just before the slug is generated.  If the callback
+from this event returns `false`, then the slugging is not performed. If anything
+else is returned, including `null`, then the slugging will be performed.
 
 The "slugged" event is fired just after a slug is generated.  It won't be called
 in the case where the model doesn't need slugging (as determined by the `needsSlugging()`

--- a/src/SluggableObserver.php
+++ b/src/SluggableObserver.php
@@ -50,8 +50,8 @@ class SluggableObserver
      */
     protected function generateSlug(Model $model, string $event)
     {
-        // If the "slugging" event returns a value, abort
-        if ($this->fireSluggingEvent($model, $event) !== null) {
+        // If the "slugging" event returns false, abort
+        if ($this->fireSluggingEvent($model, $event) === false) {
             return;
         }
         $wasSlugged = $this->slugService->slug($model);

--- a/tests/EventTests.php
+++ b/tests/EventTests.php
@@ -1,6 +1,7 @@
 <?php namespace Cviebrock\EloquentSluggable\Tests;
 
 use Cviebrock\EloquentSluggable\Tests\Listeners\AbortSlugging;
+use Cviebrock\EloquentSluggable\Tests\Listeners\DoNotAbortSlugging;
 use Cviebrock\EloquentSluggable\Tests\Models\Post;
 
 /**
@@ -35,6 +36,27 @@ class EventTests extends TestCase
      *
      * @todo Figure out how to accurately test Eloquent model events
      */
+    public function testDoNotCancelSluggingEventWhenItReturnsAnythingOtherThanFalse()
+    {
+        $this->markTestIncomplete('Event tests are not yet reliable.');
+
+        $this->app['events']->listen('eloquent.slugging: ' . Post::class, DoNotAbortSlugging::class);
+
+        $post = Post::create([
+            'title' => 'My Test Post'
+        ]);
+
+        $this->expectsEvents([
+            'eloquent.slugging: ' . Post::class,
+        ]);
+
+        $this->doesntExpectEvents([
+            'eloquent.slugged: ' . Post::class,
+        ]);
+
+        $this->assertEquals('my-test-post', $post->slug);
+    }
+
     public function testCancelSluggingEvent()
     {
         $this->markTestIncomplete('Event tests are not yet reliable.');

--- a/tests/Listeners/DoNotAbortSlugging.php
+++ b/tests/Listeners/DoNotAbortSlugging.php
@@ -1,0 +1,21 @@
+<?php
+namespace Cviebrock\EloquentSluggable\Tests\Listeners;
+
+/**
+ * Class AbortSlugging
+ *
+ * @package Tests\Listeners
+ */
+class DoNotAbortSlugging
+{
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string $event
+     * @return bool
+     */
+    public function handle($model, $event)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
The `slugging` event mentions that if `false` is returned, the slug is not done, but the code tells me something different. If you return anything but `null`, the slug will not be done. 

I have updated it so it asserts for `=== false` and not `!== null`. 

I though of chaging it to return `true` when the slugging should be done but this could be backwards incompatible to other users. But in the future you should really consider this for the sake of assertion istead of assumption. 

Thanks for maintaining this lib! 

----
Thank you for helping to make this package better!

Please make sure you've read [CONTRIBUTING.md](https://github.com/cviebrock/eloquent-sluggable/blob/master/CONTRIBUTING.md) 
before submitting your pull request, and that you have:

- [x] provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- [x] used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- [x] added tests
- [x] documented any change in behaviour (e.g. updated the `README.md`, etc.)
- [x] only submitted one pull request per feature

**Thank you!**
