### PR TITLE
4.4

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 4
 :minor: 4
-:patch: 1
+:patch: 2
 :special: ''

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
   exclude:
     - php: 7.2
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+    - php: 7.3
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+    - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 env:
   - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.4.2 - DD-MMM-2019
+
+- PHP 7.4 compatibility fix
+
 ## 4.4.1 - 04-Jan-2018
 
 - Better exception message when calling `SlugService::createSlug` with an invalid attribute (#402, thanks @lptn)
@@ -52,7 +56,7 @@
 
 ## 4.1.1 - 12-Oct-2016
 
-- Fix for slugs updating when they don't need to, when using `onUpdate` with `unique` (#317) 
+- Fix for slugs updating when they don't need to, when using `onUpdate` with `unique` (#317)
 
 
 ## 4.1.0 - 14-Sep-2016
@@ -69,7 +73,7 @@
 
 ## 4.0.3 - 15-Jul-2016
 
-- Added `$config` argument to `SlugService::createSlug` method for optionally overriding 
+- Added `$config` argument to `SlugService::createSlug` method for optionally overriding
   the configuration for a statically generated slug (#286).
 
 
@@ -107,7 +111,7 @@
   - `createSlug()` is no longer a static method on the model, but is a public method
     on the _SlugService_ class, with a different method signature (see docs).
   - Removed artisan command to add slug column to tables.  You will need to do this
-    (pretty simple) task yourself now. 
+    (pretty simple) task yourself now.
   - Several bug fixes.
 - See [UPGRADING.md](UPGRADING.md) for details.
 

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -136,7 +136,7 @@ class SlugService
             return $value;
         }, (array) $from);
 
-        return implode($sourceStrings, ' ');
+        return implode(' ', $sourceStrings);
     }
 
     /**


### PR DESCRIPTION
This pull request is a backport of #486 to version 4.4.

Since 4.4 is the branch for Laravel 5.5 (LTS) which is still active until [Aug 30th, 2020](https://laravel-news.com/laravel-release-process), this fix enables PHP 7.4 + Laravel 5.5 cohabitance for this package.