### PR TITLE
Support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5",
         "cocur/slugify": "^4.0",
-        "illuminate/config": "^6.0",
-        "illuminate/database": "^6.0",
-        "illuminate/support": "^6.0"
+        "illuminate/config": "^6.0|^7.0",
+        "illuminate/database": "^6.0|^7.0",
+        "illuminate/support": "^6.0|^7.0"
     },
     "require-dev": {
         "limedeck/phpunit-detailed-printer": "^5.0",


### PR DESCRIPTION
This adds support for Laravel 6 or 7, as well as increases the PHP requirement to be minimally compatible with both versions.