### PR TITLE
update defaultConfig variable, adding onUpdate attribute

### DIFF
--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -61,7 +61,7 @@ class SlugService
      */
     public function getConfiguration(array $overrides = []): array
     {
-        $defaultConfig = config('sluggable', []);
+        $defaultConfig = config('sluggable', ['onUpdate' => false]);
 
         return array_merge($defaultConfig, $overrides);
     }


### PR DESCRIPTION
The 'sluggable' configuration file is not always detected, so the onUpdate property is not found and the 'needsSlugging' method needs it.

This property is added to the configuration array returned by default in config ('sluggable').