### PR TITLE
Better Handling with translatables

### DIFF
--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -130,7 +130,7 @@ class SlugService
         }
 
         $sourceStrings = array_map(function($key) {
-            $value = data_get($this->model, $key);
+            $value = data_get($this->model, $key,$this->model->getAttribute($key));
             if (is_bool($value)) {
                 $value = (int) $value;
             }

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -130,7 +130,7 @@ class SlugService
         }
 
         $sourceStrings = array_map(function($key) {
-            $value = data_get($this->model, $key,$this->model->getAttribute($key));
+            $value = data_get($this->model, $key, $this->model->getAttribute($key));
             if (is_bool($value)) {
                 $value = (int) $value;
             }


### PR DESCRIPTION

If the property is **translatable** (using either spatie or Astrotomic package), the "data_get" function, returns null value.
With this modification, the SlugService takes advantage of the 'getAttribute' method as fallback to null, where in case of translatables it considers all the overrides, returning at least the localized value

-------------------

_As an extra you may consider something like:_
```php 

//Model
  public function sluggable()
    {
        return [
            'slug' => [
                'source' => function (Model $model) {
                    return $model->getTranslation('title','en');//'a  callback that returns string
                }
            ]
        ];
    }




//SlugService

    /**
     * Get the source string for the slug.
     *
     * @param  mixed  $from
     *
     * @return string
     */
    protected function getSlugSource($from): string
    {
        if (is_null($from)) {
            return $this->model->__toString();
        }

        if (is_callable($from)) {
            $value = $from( $this->model );
            return is_string($value) ? $value : null;
        }
....
```

If you are interested on the callback, I can make a try 