### PR TITLE
Source config on sluggable can be callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ public function sluggable()
             'source' => ['author.lastname', 'author.firstname'],
             'separator' => '_'
         ],
+        'subtitle-slug' => [
+            'source' => function(Model $model){ 
+                   return $model->title.$model->subtitle;
+            }
+        ],
     ];
 }
 ```

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -128,6 +128,10 @@ class SlugService
         if (is_null($from)) {
             return $this->model->__toString();
         }
+        if (is_callable($from)) {
+            $value = $from( $this->model );
+            return is_string($value) ? $value : null;
+        }
 
         $sourceStrings = array_map(function($key) {
             $value = data_get($this->model, $key, $this->model->getAttribute($key));

--- a/tests/BaseTests.php
+++ b/tests/BaseTests.php
@@ -4,6 +4,7 @@ use Cviebrock\EloquentSluggable\Tests\Models\Author;
 use Cviebrock\EloquentSluggable\Tests\Models\Post;
 use Cviebrock\EloquentSluggable\Tests\Models\PostNotSluggable;
 use Cviebrock\EloquentSluggable\Tests\Models\PostShortConfig;
+use Cviebrock\EloquentSluggable\Tests\Models\PostWithCallableSource;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomCallableMethod;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomEngine;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomEngine2;
@@ -482,4 +483,18 @@ class BaseTests extends TestCase
         ]);
         $this->assertEquals('0', $post->slug);
     }
+
+    /**
+     * Test using a custom separator.
+     */
+    public function testCallableSource()
+    {
+        $post = PostWithCallableSource::create([
+            'title' => 'title',
+            'subtitle' => 'subtitle'
+        ]);
+
+        $this->assertEquals('title-test-subtitle', $post->slug);
+    }
+
 }

--- a/tests/Models/PostWithCallableSource.php
+++ b/tests/Models/PostWithCallableSource.php
@@ -1,0 +1,27 @@
+<?php namespace Cviebrock\EloquentSluggable\Tests\Models;
+
+/**
+ * Class PostWithCallableSource
+ *
+ * @package Cviebrock\EloquentSluggable\Tests\Models
+ */
+class PostWithCallableSource extends Post
+{
+
+    /**
+     * Return the sluggable configuration array for this model.
+     *
+     * @return array
+     */
+    public function sluggable()
+    {
+        return [
+            'slug' => [
+                'source' => function (Post $post) {
+                    return "{$post->title}-test-{$post->subtitle}";
+                }
+            ]
+        ];
+    }
+
+}


### PR DESCRIPTION

Hello again,

I did a first trial, where the source of the slug can be a callable function too, so it can be configured as the developer likes