### PR TITLE
add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "require": {
         "php": "^7.2.5",
         "cocur/slugify": "^4.0",
-        "illuminate/config": "^7.0",
-        "illuminate/database": "^7.0",
-        "illuminate/support": "^7.0"
+        "illuminate/config": "^7.0|^8.0",
+        "illuminate/database": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0"
     },
     "require-dev": {
         "limedeck/phpunit-detailed-printer": "^5.0",


### PR DESCRIPTION
This PR adds Laravel 8 compatibility without removing Laravel 7 compatibility. So it's an alternative to https://github.com/cviebrock/eloquent-sluggable/pull/524

Tests seem to be running fine:
![Screenshot 2020-09-08 at 10 31 01](https://user-images.githubusercontent.com/1032474/92490040-7d826800-f1be-11ea-8967-d68ee49d3fa8.png)

Browser tests too:
![2020-09-08 10 26 32](https://user-images.githubusercontent.com/1032474/92490066-87a46680-f1be-11ea-831d-368fc3b1e74f.gif)


Don't know which way you'd rather go @cviebrock - let me know.

Cheers!

