### PR TITLE
PHP 8 Support for Laravel 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 env:
   - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
@@ -19,6 +20,8 @@ env:
 matrix:
   exclude:
     - php: 7.4
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+    - php: 8.0
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Easy creation of slugs for your Eloquent models in Laravel.
 
-> **NOTE**: These instructions are for Laravel 6.0.  If you are using Laravel 5.8, please
+> **NOTE**: These instructions are for Laravel 7.0.  If you are using Laravel 5.8, please
 > see the [previous version's docs](https://github.com/cviebrock/eloquent-sluggable/tree/4.8).
 
 [![Build Status](https://travis-ci.org/cviebrock/eloquent-sluggable.svg?branch=master&format=flat)](https://travis-ci.org/cviebrock/eloquent-sluggable)
@@ -141,7 +141,7 @@ class Post extends Model
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "cocur/slugify": "^4.0",
         "illuminate/config": "^7.0",
         "illuminate/database": "^7.0",

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -56,7 +56,7 @@ class Post extends Model
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostShortConfig.php
+++ b/tests/Models/PostShortConfig.php
@@ -13,7 +13,7 @@ class PostShortConfig extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug'

--- a/tests/Models/PostShortConfigWithScopeHelpers.php
+++ b/tests/Models/PostShortConfigWithScopeHelpers.php
@@ -17,7 +17,7 @@ class PostShortConfigWithScopeHelpers extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug_field'

--- a/tests/Models/PostWithCustomCallableMethod.php
+++ b/tests/Models/PostWithCustomCallableMethod.php
@@ -16,7 +16,7 @@ class PostWithCustomCallableMethod extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithCustomMethod.php
+++ b/tests/Models/PostWithCustomMethod.php
@@ -16,7 +16,7 @@ class PostWithCustomMethod extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithCustomSeparator.php
+++ b/tests/Models/PostWithCustomSeparator.php
@@ -15,7 +15,7 @@ class PostWithCustomSeparator extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithCustomSource.php
+++ b/tests/Models/PostWithCustomSource.php
@@ -15,7 +15,7 @@ class PostWithCustomSource extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithCustomSuffix.php
+++ b/tests/Models/PostWithCustomSuffix.php
@@ -18,7 +18,7 @@ class PostWithCustomSuffix extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithEmptySeparator.php
+++ b/tests/Models/PostWithEmptySeparator.php
@@ -15,7 +15,7 @@ class PostWithEmptySeparator extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithIncludeTrashed.php
+++ b/tests/Models/PostWithIncludeTrashed.php
@@ -11,7 +11,7 @@
 class PostWithIncludeTrashed extends Post
 {
 
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithMaxLength.php
+++ b/tests/Models/PostWithMaxLength.php
@@ -13,7 +13,7 @@ class PostWithMaxLength extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithMaxLengthSplitWords.php
+++ b/tests/Models/PostWithMaxLengthSplitWords.php
@@ -13,7 +13,7 @@ class PostWithMaxLengthSplitWords extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithMultipleSlugs.php
+++ b/tests/Models/PostWithMultipleSlugs.php
@@ -13,7 +13,7 @@ class PostWithMultipleSlugs extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithMultipleSources.php
+++ b/tests/Models/PostWithMultipleSources.php
@@ -13,7 +13,7 @@ class PostWithMultipleSources extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithNoSource.php
+++ b/tests/Models/PostWithNoSource.php
@@ -15,7 +15,7 @@ class PostWithNoSource extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithOnUpdate.php
+++ b/tests/Models/PostWithOnUpdate.php
@@ -15,7 +15,7 @@ class PostWithOnUpdate extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithRelation.php
+++ b/tests/Models/PostWithRelation.php
@@ -17,7 +17,7 @@ class PostWithRelation extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithReservedSlug.php
+++ b/tests/Models/PostWithReservedSlug.php
@@ -15,7 +15,7 @@ class PostWithReservedSlug extends Post
      *
      * @return array
      */
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [

--- a/tests/Models/PostWithSoftDeletingIncludeTrashed.php
+++ b/tests/Models/PostWithSoftDeletingIncludeTrashed.php
@@ -15,7 +15,7 @@ class PostWithSoftDeletingIncludeTrashed extends Post
 
     use SoftDeletes;
 
-    public function sluggable()
+    public function sluggable(): array
     {
         return [
             'slug' => [


### PR DESCRIPTION
This PR backports PHP 8 compatibility to the 7.x branch from #533

- The rationale behind the change is that  Laravel 7.x (and also 6.x) supports PHP 8.
- The sibling PR for the 6.x branch is also going to follow
- I haven't found any reference to PHP versions in README, but I've slightly updated it
- Since the conversion to Github Actions hasn't been completed yet, I've updated Travis for now
