### PR TITLE
Fix null slug

### DIFF
--- a/src/SluggableObserver.php
+++ b/src/SluggableObserver.php
@@ -70,17 +70,19 @@ class SluggableObserver
     /**
      * @param \Illuminate\Database\Eloquent\Model $model
      * @param string $event
-     * @return void
+     * @return bool
      */
-    protected function generateSlug(Model $model, string $event): void
+    protected function generateSlug(Model $model, string $event): bool
     {
         // If the "slugging" event returns false, abort
         if ($this->fireSluggingEvent($model, $event) === false) {
-            return;
+            return false;
         }
         $wasSlugged = $this->slugService->slug($model);
 
         $this->fireSluggedEvent($model, $wasSlugged);
+
+        return $wasSlugged;
     }
 
     /**

--- a/tests/BaseTests.php
+++ b/tests/BaseTests.php
@@ -531,6 +531,20 @@ class BaseTests extends TestCase
     }
 
     /**
+     * Test that when using the SAVED observer the slug is
+     * actually persisted in storage.
+     */
+    public function testOnSavedPersistsSlug()
+    {
+        $post = PostWithIdSourceOnSaved::create([
+            'title' => 'My Test Post',
+        ]);
+        $post->refresh();
+
+        self::assertEquals('my-test-post-1', $post->slug);
+    }
+
+    /**
      * Test that you can't use the model's primary key
      * as part of the source field if the sluggableEvent
      * is the default SAVING.


### PR DESCRIPTION
This is a recurring issue that I believe is being described in issues #553 and #554. The SAVED observer was checking the response from the `generateSlug` method before persisting the model with the new slug to storage. But `generateSlug` always returned `void`, causing the expression to always evaluate `false`. 

This could be fixed by returning a `bool` from `generateSlug()` or removing the conditional. I opted for the former to prevent persisting to the database unnecessarily. 

I added the test `testOnSavedPersistsSlug` to the `BaseTest` file, which demonstrated the bug and validates the fix.



- ✅ provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- ✅ used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- ✅ added tests
- ✅ documented any change in behaviour (e.g. updated the `README.md`, etc.)
- ✅ only submitted one pull request per feature
