### PR TITLE
Fix: Models not saving. Issue #559

### DIFF
--- a/src/SluggableObserver.php
+++ b/src/SluggableObserver.php
@@ -50,7 +50,7 @@ class SluggableObserver
             return;
         }
 
-        return $this->generateSlug($model, 'saving');
+        $this->generateSlug($model, 'saving');
     }
 
     /**

--- a/tests/BaseTests.php
+++ b/tests/BaseTests.php
@@ -316,6 +316,28 @@ class BaseTests extends TestCase
     }
 
     /**
+     * Test that models are still updated even if slug is not updated.
+     *
+     * @see https://github.com/cviebrock/eloquent-sluggable/issues/559
+     */
+    public function testModelStillSavesWhenSlugIsNotUpdated()
+    {
+        $post = Post::create([
+            'title' => 'My Post',
+            'subtitle' => 'My First Subtitle',
+        ]);
+
+        self::assertEquals('my-post', $post->slug);
+
+        $post->subtitle = 'My Second Subtitle';
+        $post->save();
+        $post->refresh();
+
+        self::assertEquals('my-post', $post->slug);
+        self::assertEquals('My Second Subtitle', $post->subtitle);
+    }
+
+    /**
      * Test generating slug from related model field.
      */
     public function testSlugFromRelatedModel(): void


### PR DESCRIPTION
This is in response to an issue caused by my latest PR. Now that saving actually returns the results of `generateSlug`, it was returning `false` if the slug was not updated--preventing the Laravel saving observer from updating the model. I couldn't think of a single reason that `saving` in the `SluggableObserver` should ever override the model update so I removed the return statement entirely. Before version 8.0.6 this method was always guaranteed to return `null`, so this should simply be reverting the behavior of the method to that patch. 

It feels weird just deleting a `return` statement, so I am happy to look closer if I have overlooked anything; but I wrote a test for this behavior and tested the change in a current Laravel project and the problem seems to be resolved. I can't think of any further features this should cripple. 

--------------------------------------------------------------

- ✅ provided a rationale for your change (I try not to add features that are going to have a limited user-base)
- ✅ used the [PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- ✅ added tests
- ☑️   ~~documented any change in behaviour (e.g. updated the `README.md`, etc.)~~ N/A
- ✅ only submitted one pull request per feature
