### PR TITLE
Fix event tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,6 @@ to use your model's primary key as part of the source fields for your slugs.
 
 ## Events
 
-> **NOTE:** Events should be working but are not fully tested yet.
-> [Please help me out!](#bugs-suggestions-and-contributions)
-
 Sluggable models will fire two Eloquent model events: "slugging" and "slugged".
   
 The "slugging" event is fired just before the slug is generated.  If the callback

--- a/src/SluggableObserver.php
+++ b/src/SluggableObserver.php
@@ -90,9 +90,9 @@ class SluggableObserver
      *
      * @param  \Illuminate\Database\Eloquent\Model $model
      * @param  string $event
-     * @return array|null
+     * @return bool|null
      */
-    protected function fireSluggingEvent(Model $model, string $event): ?array
+    protected function fireSluggingEvent(Model $model, string $event): ?bool
     {
         return $this->events->until('eloquent.slugging: ' . get_class($model), [$model, $event]);
     }

--- a/tests/Listeners/AbortSlugging.php
+++ b/tests/Listeners/AbortSlugging.php
@@ -17,8 +17,6 @@ class AbortSlugging
      */
     public function handle(Model $model, string $event): bool
     {
-        echo "SLUGGING ABORTED!\n";
-
         return false;
     }
 }


### PR DESCRIPTION
This PR fixes #556 and updates the event tests.

Notable changes:
- I've deleted the echo statement `echo "SLUGGING ABORTED!\n";` in [tests/Listeners/AbortSlugging.php](https://github.com/standaniels/eloquent-sluggable/commit/2bc6ba9f26720049f5a32a80865a7b294fda606d#diff-50aae701f8a5754a98c7be14f06327e777aa30a6c2bd5e80a572305d54af7e42) since I don't think it's used anywhere.
- I've removed the `testSluggedEvent` method in [tests/EventTests.php ](https://github.com/cviebrock/eloquent-sluggable/blob/master/tests/EventTests.php#L81-L96) since it seems to be a duplicate of `testEventsAreFired`.