### PR TITLE
Laravel 9 compability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
     "require": {
         "php": "^7.3|^8.0",
         "cocur/slugify": "^4.0",
-        "illuminate/config": "^8.0",
-        "illuminate/database": "^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/config": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/support": "^9.0"
     },
     "require-dev": {
         "limedeck/phpunit-detailed-printer": "^6.0",
         "mockery/mockery": "^1.4.2",
-        "orchestra/database": "^6.0",
-        "orchestra/testbench": "^6.0",
+        "orchestra/database": "^7.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.4"
     },
     "autoload": {


### PR DESCRIPTION
composer.json updated for Laravel 9 which will be released this month. 

The patch can be tested/used by others by adding my repository to composer.json until it's released officially.

```
{
    "require": {
        "cviebrock/eloquent-sluggable": "dev-laravel-9-patch",
    }
}

"repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/carbonvader/eloquent-sluggable.git"
        }
]
```