### PR TITLE
Adds support for Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.0]
+        php: [8.0, 8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [8.0]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ version of the package.
 
 | Laravel Version | Package Version |
 |:---------------:|:---------------:|
+|       9.0       |      ^9.0       |
 |       8.0       |      ^8.0       |
 |       7.0       |      ^7.0       |
 |       6.0       |      ^6.0       |

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "cocur/slugify": "^4.0",
-        "illuminate/config": "^8.0",
-        "illuminate/database": "^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/config": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/support": "^9.0"
     },
     "require-dev": {
         "limedeck/phpunit-detailed-printer": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     "require-dev": {
         "limedeck/phpunit-detailed-printer": "^6.0",
         "mockery/mockery": "^1.4.2",
-        "orchestra/database": "^6.0",
-        "orchestra/testbench": "^6.0",
+        "orchestra/database": "^7.0|dev-master",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "limedeck/phpunit-detailed-printer": "^6.0",
         "mockery/mockery": "^1.4.2",
-        "orchestra/database": "^7.0|dev-master",
+        "orchestra/database": "^7.0",
         "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.4"
     },


### PR DESCRIPTION
Hey @cviebrock ,

Laravel 9 is just around the corner, due in 6 days. I thought we'd get in front of this thing, and provide support before the launch. **Tested L9 against this package, everything works fine, tests run fine, we're good to go** 🎉

Notes:
- "_As of version 6.0, the package's version should match the Laravel version._", so if you merge this, please also tag v9; I've already made the changes to README.md to account for this;

Thanks for a great package 🙏
Cheers!