### PR TITLE
Feature/custom method array call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /vendor/
 composer.lock
 composer.phar
+/.idea

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use ReflectionClass;
-use ReflectionMethod;
 
 /**
  * Class SlugService
@@ -180,7 +179,7 @@ class SlugService
             // check method is exists in class declared
             $reflection_class = new ReflectionClass($method[0]);
             if ($reflection_class->hasMethod(($method[1] ?? ''))) {
-                throw new \UnexpectedValueException(sprintf('Call to undefined method %s::%s', $method[1], $method[0]));
+                throw new \BadMethodCallException(sprintf('Call to undefined method %s::%s', $method[1], $method[0]));
             }
 
             $slug = call_user_func([$method[0], $method[1]], $source, $separator);

--- a/tests/BaseTests.php
+++ b/tests/BaseTests.php
@@ -9,6 +9,7 @@ use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomEngine;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomEngine2;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomEngineOptions;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomMethod;
+use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomMethodArrayCall;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomSeparator;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithCustomSource;
 use Cviebrock\EloquentSluggable\Tests\Models\PostWithIdSource;
@@ -91,6 +92,18 @@ class BaseTests extends TestCase
     public function testCustomMethod(): void
     {
         $post = PostWithCustomMethod::create([
+            'title' => 'A Post Title',
+            'subtitle' => 'A Subtitle'
+        ]);
+        self::assertEquals('eltit-tsop-a', $post->slug);
+    }
+
+    /**
+     * Test building a slug using a custom method.
+     */
+    public function testCustomMethodArrayCall(): void
+    {
+        $post = PostWithCustomMethodArrayCall::create([
             'title' => 'A Post Title',
             'subtitle' => 'A Subtitle'
         ]);

--- a/tests/BaseTests.php
+++ b/tests/BaseTests.php
@@ -99,7 +99,7 @@ class BaseTests extends TestCase
     }
 
     /**
-     * Test building a slug using a custom method.
+     * Test building a slug using a custom method with array call.
      */
     public function testCustomMethodArrayCall(): void
     {

--- a/tests/Classes/SluggableCustomMethod.php
+++ b/tests/Classes/SluggableCustomMethod.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Cviebrock\EloquentSluggable\Tests\Classes;
+
+use Illuminate\Support\Str;
+
+class SluggableCustomMethod
+{
+    public static function slug($string, $separator = '-')
+    {
+        return strrev(Str::slug($string, $separator));
+    }
+}

--- a/tests/Models/PostWithCustomMethodArrayCall.php
+++ b/tests/Models/PostWithCustomMethodArrayCall.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Cviebrock\EloquentSluggable\Tests\Models;
+
+use Cviebrock\EloquentSluggable\Tests\Classes\SluggableCustomMethod;
+
+class PostWithCustomMethodArrayCall extends Post
+{
+    /**
+     * Return the sluggable configuration array for this model.
+     *
+     * @return array
+     */
+    public function sluggable(): array
+    {
+        return [
+            'slug' => [
+                'source' => 'title',
+                'method' => [SluggableCustomMethod::class, 'slug']
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
To make a slug, you can use special methods and change its process.
A Closure must be received to change this process.
Also, Closure can be defined in `config/sluggable.php` file.
Now the issue and the problem it causes is that when we want to cache the config files using `config:cache` command during the program execution in production mode.
This is exactly the problem and the reason is that Closures cannot be cached.

- [x] And now I tried to introduce the custom method in the form of an array to Slug Service.

**I hope I have contributed in a positive way to this practical package :shipit:**
**Thank you!**
