### PR TITLE
Laravel 11 Preparation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2]
+        php: [8.2, 8.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 11.x.x - xx-xxx-xxxx
+
+- Added Laravel 11 support
+- Changed the minimum PHP version to v8.2
+
 ## 10.0.x - xx-xxx-xxxx
 
 - fix for larastan issue (#596, thanks @WalrusSoup)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ version of the package.
 
 | Laravel Version | Package Version |
 |:---------------:|:---------------:|
+|      11.0       |     ^11.0       |
 |      10.0       |     ^10.0       |
 |       9.0       |      ^9.0       |
 |       8.0       |      ^8.0       |

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
             "providers": [
                 "Cviebrock\\EloquentSluggable\\ServiceProvider"
             ]
+        },
+        "branch-alias": {
+            "dev-master": "11.0.x-dev"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "cocur/slugify": "^4.3",
-        "illuminate/config": "^10.0",
-        "illuminate/database": "^10.0",
-        "illuminate/support": "^10.0"
+        "illuminate/config": "^11.0",
+        "illuminate/database": "^11.0",
+        "illuminate/support": "^11.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.4",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.28"
     },
     "autoload": {


### PR DESCRIPTION
### Rationale

This PR prepares the Laravel 11 support of this package. Although Laravel 11 hasn't been released yet, some package maintainers (like myself :slightly_smiling_face:) have already been preparing for the upcoming Laravel 11 release.

Some of the packages and apps I maintain depend on this package. Having this PR merged will help me and others keep testing with the soon-to-be-released Laravel 11 version.

### How

- The changes should stay on the master branch
- No need to tag `11.0.0` yet
- Using composer's [branch alias feature](https://getcomposer.org/doc/articles/aliases.md), dependents can request the pre-release `11.x` version of this package
- PHP 8.1 support has been dropped to be in sync with Laravel 11 requirements

Cheers!
