### PR TITLE
Add ability to customize slug uniqueness resolution

### DIFF
--- a/resources/config/sluggable.php
+++ b/resources/config/sluggable.php
@@ -80,6 +80,15 @@ return [
     'unique' => true,
 
     /**
+     * If the slug is not unique and you want to try to make it unique by replacing
+     * some other parts of the slug, you can set this to a closure which accepts
+     * the base slug, the separator, and a Collection of the other "similar" slugs.
+     * The closure should return the new unique slug to use, if the slug is still not
+     * unique, it will append a suffix.
+     */
+    'uniqueUsing' => null,
+
+    /**
      * If you are enforcing unique slugs, the default is to add an
      * incremental value to the end of the base slug.  Alternatively, you
      * can change this value to a closure that accepts three parameters:

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -303,6 +303,20 @@ class SlugService
             }
         }
 
+        // If uniqueUsing is set to a closure, use it to generate a new "unique" slug
+        if (isset($config['uniqueUsing']) && is_callable($config['uniqueUsing'])) {
+            $using = $config['uniqueUsing'];
+
+            // Generate mew slug using the closure
+            $slugUsing = $using($slug, $separator, $list);
+
+            // Remove uniqueUsing from the config to avoid infinite loop
+            unset($config['uniqueUsing']);
+
+            // Call makeSlugUnique again with the new slug to ensure it's unique
+            return $this->makeSlugUnique($slugUsing, $config, $attribute);
+        }
+
         $method = $config['uniqueSuffix'];
         $firstSuffix = $config['firstUniqueSuffix'];
 


### PR DESCRIPTION
This pull request introduces a new feature to allow for personalization of unique slugs. If the slug is not unique and you want to try to make it unique by replacing some other parts of the slug instead of adding a suffic, you can set the `uniqueUsing` configuration option to a closure which accepts the base slug, the separator, and a Collection of the other "similar" slugs as arguments. The closure should return the new unique slug to use, if the slug is still not unique, it will append a suffix to the returned slug.

Missing: 
- [ ] added tests
- [ ] documented any change in behaviour (e.g. updated the `README.md`, etc.)
