### PR TITLE
Support PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/src/Services/SlugService.php
+++ b/src/Services/SlugService.php
@@ -76,7 +76,7 @@ class SlugService
      *
      * @return null|string
      */
-    public function buildSlug(string $attribute, array $config, bool $force = null): ?string
+    public function buildSlug(string $attribute, array $config, bool $force = false): ?string
     {
         $slug = $this->model->getAttribute($attribute);
 
@@ -407,7 +407,7 @@ class SlugService
      * @throws \InvalidArgumentException
      * @throws \UnexpectedValueException
      */
-    public static function createSlug($model, string $attribute, string $fromString, array $config = null): string
+    public static function createSlug($model, string $attribute, string $fromString, ?array $config = null): string
     {
         if (is_string($model)) {
             $model = new $model;

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -45,7 +45,7 @@ trait Sluggable
     /**
      * @inheritDoc
      */
-    public function replicate(array $except = null)
+    public function replicate(?array $except = null)
     {
         $instance = parent::replicate($except);
         (new SlugService())->slug($instance, true);


### PR DESCRIPTION
Fix all these DEPRECATED.

DEPRECATED  Cviebrock\EloquentSluggable\Sluggable::replicate(): Implicitly marking parameter $except as nullable is deprecated, the explicit nullable type must be used instead in vendor/cviebrock/eloquent-sluggable/src/Sluggable.php on line 48.


DEPRECATED  Cviebrock\EloquentSluggable\Services\SlugService::buildSlug(): Implicitly marking parameter $force as nullable is deprecated, the explicit nullable type must be used instead in vendor/cviebrock/eloquent-sluggable/src/Services/SlugService.php on line 79.


DEPRECATED  Cviebrock\EloquentSluggable\Services\SlugService::createSlug(): Implicitly marking parameter $config as nullable is deprecated, the explicit nullable type must be used instead in vendor/cviebrock/eloquent-sluggable/src/Services/SlugService.php on line 410.