### PR TITLE
Allow overriding SlugService by resolving it from the service container

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,7 +26,7 @@ class ServiceProvider extends BaseServiceProvider
     public function register()
     {
         $this->app->singleton(SluggableObserver::class, function ($app) {
-            return new SluggableObserver(new SlugService(), $app['events']);
+            return new SluggableObserver($this->app->make(SlugService::class), $app['events']);
         });
     }
 


### PR DESCRIPTION
When instantiated using `new`, the SlugService cannot be overridden by app code.
Resolving SlugService from the container, allows for overriding.