### PR TITLE
Laravel 13 support 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
     "require": {
         "php": "^8.2",
         "cocur/slugify": "^4.3",
-        "illuminate/config": "^12.0",
-        "illuminate/database": "^12.0",
-        "illuminate/support": "^12.0"
+        "illuminate/config": "^12.0 || ^13.0",
+        "illuminate/database": "^12.0 || ^13.0",
+        "illuminate/support": "^12.0 || ^13.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.65",
         "larastan/larastan": "^3.0",
         "mockery/mockery": "^1.4.4",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "pestphp/pest": "^3.7",
         "phpstan/phpstan": "^2.0"
     },


### PR DESCRIPTION
🔧 chore(composer): update package version constraints
- allow illuminate packages to use version 13.0 for compatibility
- allow orchestra/testbench to use version 11.0 for testing

Solves #627

@cviebrock 
